### PR TITLE
Removed OSX shell checks for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: bash
 sudo: required
 os:
   - linux
-  - osx
 install:
   - ./build/install.sh
 script:


### PR DESCRIPTION
This just removes a 2nd environment check. No need to have Travis check for OSX issues. 