### PR TITLE
address TRAC-816: update string_replacement; this seems to be the mos…

### DIFF
--- a/files/string_replacement
+++ b/files/string_replacement
@@ -17,6 +17,7 @@ $conf['locale_custom_strings_en'][''] = array(
   'Select a Content Model to Ingest'                             => 'Select file type to submit',
   'Add a datastream'                                             => 'Add a Supplemental File',
   'Datastreams'                                                  => 'Files',
-  'Would you like to include supplemental files with this Electronic Thesis or Dissertation?' => 'Check the box to upload supplement file(s).', 
+  'Would you like to include supplemental files with this Electronic Thesis or Dissertation?' => 'Check the box to upload supplement file(s).',
+  'Add'															 => 'Add another',
    /*Per Trac-543 REQUEST FIVE: change pdf_upload_form.inc*/
 );


### PR DESCRIPTION
…t immediate way to fix the 'Add' button on the MODS submission/edit form. This will probably need to be revisited at some point.

JIRA: [TRAC-816](https://jira.lib.utk.edu/browse/TRAC-816)

What does this PR do?
This PR updates the 'Add' button in the Thesis Advisor and Committee member(s) section of the MODS form.

How to test:
* Pull this branch.
* vagrant destroy and vagrant up OR add the appropriate text to the settings.php file
* as userA, submit an ETD
* the 'Add' button under Thesis Advisor and Committee member(s) should now read 'Add another', and should continue to say 'Add another' after being clicked.

Interested Parties:
@cdeaneGit @DonRichards @robert-patrick-waltz @pc37utn 