### PR TITLE
address TRAC-980: add file to islandora_xml_forms on `vagrant up`

### DIFF
--- a/scripts/custom_scripts/100_update_islandora_forms.sh
+++ b/scripts/custom_scripts/100_update_islandora_forms.sh
@@ -27,6 +27,7 @@ sudo cp "$HOME_DIR"/utk_isl_xml_forms/xml_forms/UTK_ir_datasets.xml "$DRUPAL_HOM
 # Add post-process transforms
 echo "Add post-process XSL transforms."
 sudo cp "$HOME_DIR"/utk_isl_xml_forms/post_process_transforms/*.xsl "$DRUPAL_HOME"/sites/all/modules/islandora_xml_forms/builder/self_transforms
+sudo cp "$HOME_DIR"/utk_isl_xml_forms/post_process_transforms/trace-disciplines-list-comp.xml "$DRUPAL_HOME"/sites/all/modules/islandora_xml_forms/builder/self_transforms
 
 # Fix ownership on the copied post-process transforms
 echo "Correct ownership on the post-process XSL transforms."


### PR DESCRIPTION
** JIRA Ticket**: [TRAC-980](https://jira.lib.utk.edu/browse/TRAC-980)
# What does this Pull Request do?
Adds a line to pull in a file (`trace-disciplines-list-comp.xml`) into `islandora_xml_forms/builder/self_transforms`. In recent days, many of us have seen the following error:
```
Warning: XSLTProcessor::transformToDoc(): I/O warning : failed to load external entity "/var/www/drupal/sites/all/modules/islandora_xml_forms/builder/self_transforms/trace-disciplines-list-comp.xml" in xml_form_builder_transform_metadata_datastream() (line 611 of /var/www/drupal/sites/all/modules/islandora_xml_forms/builder/xml_form_builder.module).
```
This currently-missing file is the culprit.
# What's new?
This file is a sub-component of our post-processing transform.
# How should this be tested?
1. `vagrant destroy -f`
2. `vagrant up`
3. `vagrant ssh`
4. `ls /var/www/drupal/sites/all/modules/islandora_xml_forms/builder/self_transforms`
5. If the file `trace-disciplines-list-comp.xml` is there, then pass, otherwise please let me know.
# Interested parties
@DonRichards @robert-patrick-waltz @pc37utn @cdeaneGit 
