### PR TITLE
address TRAC-1003

### DIFF
--- a/scripts/modules.sh
+++ b/scripts/modules.sh
@@ -56,6 +56,7 @@ git clone https://github.com/utkdigitalinitiatives/islandora_scholar
 git clone https://github.com/utkdigitalinitiatives/islandora_solr_metadata
 git clone https://github.com/utkdigitalinitiatives/islandora_xml_forms
 git clone https://github.com/utkdigitalinitiatives/islandora_binary_object
+git clone https://github.com/utkdigitalinitiatives/islandora_batch_digital_commons
 
 # set core.filemode on our forks
 cd "$DRUPAL_HOME"/sites/all/modules/islandora_scholar || exit


### PR DESCRIPTION
** JIRA Ticket**: [TRAC-1003](https://jira.lib.utk.edu/browse/TRAC-1003)
# What does this Pull Request do?
Add the islandora_batch_digital_commons module as a dependency to modules.sh.

# What's new?
Added a new module dependency to `modules.sh`.

# How should this be tested?
Testing should be reflected in [trace_ext_workflow's PR no.13](https://github.com/utkdigitalinitiatives/trace_ext_workflow/pull/13) -- changes to the trace_ext_workflow module necessitate a dependency that we don't have installed/articulated in our current startup script(s). If the testing for trace_ext_workflow PR 13 passes, then this should be a pass.

For the sake of completeness though, if you `vagrant destroy -f && vagrant up` and watch the output of `vagrant up`, you should *not* see an error that reports a fatal class error; e.g. 
```
    default: Ingesting Sample Thesis Objects
    default: SetId: 1                                                                    [ok]
    default: Ingested utk.ir.td:1.                                                       [ok]
    default: PHP Fatal error:  Class 'IslandoraScanBatchObjectDigitalCommons' not found in /var/www/drupal/sites/all/modules/trace_ext_workflow/trace_ext_workflow.module on line 234
    default: Drush command terminated abnormally due to an unrecoverable error.       [error]
    default: Error: Class 'IslandoraScanBatchObjectDigitalCommons' not found in
    default: /var/www/drupal/sites/all/modules/trace_ext_workflow/trace_ext_workflow.module,
    default: line 234
    default: The external command could not be executed due to an application         [error]
    default: error.
    default: Running custom script /vagrant/scripts/custom_scripts/871_ingest_sample_articles.sh
```
# Additional Notes:

# Interested parties
@robert-patrick-waltz @DonRichards 