### PR TITLE
Trac 1029a

### DIFF
--- a/files/islandora-solr-facet.tpl.php
+++ b/files/islandora-solr-facet.tpl.php
@@ -236,43 +236,28 @@
 <ul role="listbox" class="islandora-solr-facet">
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2018-01-01 TO 2018-12-31]?type=edismax&sort=timestamp+desc">2018</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2018-01-01 TO 2018-12-31]?type=edismax&sort=timestamp+desc">2018</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2018-01-01 TO 2018-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2018-01-01 TO 2018-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2018-01-01 TO 2018-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2018-01-01 TO 2018-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
     </li>
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2017-01-01 TO 2017-12-31]?type=edismax&sort=timestamp+desc">2017</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2017-01-01 TO 2017-12-31]?type=edismax&sort=timestamp+desc">2017</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2017-01-01 TO 2017-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2017-01-01 TO 2017-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2017-01-01 TO 2017-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
-              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
-          </span>
-      </span>
-    </li>
-
-
-    <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2016-01-01 TO 2016-12-31]?type=edismax&sort=timestamp+desc">2016</a>
-        <span class="plusminus">
-          <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2016-01-01 TO 2016-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
-              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
-          </span>
-          <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2016-01-01 TO 2016-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2017-01-01 TO 2017-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -280,42 +265,14 @@
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2015-01-01 TO 2015-12-31]?type=edismax&sort=timestamp+desc">2015</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2016-01-01 TO 2016-12-31]?type=edismax&sort=timestamp+desc">2016</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2015-01-01 TO 2015-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2016-01-01 TO 2016-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2015-01-01 TO 2015-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
-              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
-          </span>
-      </span>
-    </li>
-
-    <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2014-01-01 TO 2014-12-31]?type=edismax&sort=timestamp+desc">2014</a>
-        <span class="plusminus">
-          <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2014-01-01 TO 2014-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
-              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
-          </span>
-          <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2014-01-01 TO 2014-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
-              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
-          </span>
-      </span>
-    </li>
-
-    <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2013-01-01 TO 2013-12-31]?type=edismax&sort=timestamp+desc">2013</a>
-        <span class="plusminus">
-          <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2013-01-01 TO 2013-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
-              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
-          </span>
-          <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2013-01-01 TO 2013-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2016-01-01 TO 2016-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -323,85 +280,42 @@
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2012-01-01 TO 2012-12-31]?type=edismax&sort=timestamp+desc">2012</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2015-01-01 TO 2015-12-31]?type=edismax&sort=timestamp+desc">2015</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2012-01-01 TO 2012-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2015-01-01 TO 2015-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2012-01-01 TO 2012-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2015-01-01 TO 2015-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
     </li>
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2011-01-01 TO 2011-12-31]?type=edismax&sort=timestamp+desc">2011</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2014-01-01 TO 2014-12-31]?type=edismax&sort=timestamp+desc">2014</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2011-01-01 TO 2011-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2014-01-01 TO 2014-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2011-01-01 TO 2011-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2014-01-01 TO 2014-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
     </li>
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2010-01-01 TO 2010-12-31]?type=edismax&sort=timestamp+desc">2010</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2013-01-01 TO 2013-12-31]?type=edismax&sort=timestamp+desc">2013</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2010-01-01 TO 2010-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2013-01-01 TO 2013-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2010-01-01 TO 2010-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
-              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
-          </span>
-      </span>
-    </li>
-
-
-    <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2009-01-01 TO 2009-12-31]?type=edismax&sort=timestamp+desc">2009</a>
-        <span class="plusminus">
-          <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2009-01-01 TO 2009-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
-              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
-          </span>
-          <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2009-01-01 TO 2009-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
-              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
-          </span>
-      </span>
-    </li>
-
-    <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2008-01-01 TO 2008-12-31]?type=edismax&sort=timestamp+desc">2008</a>
-        <span class="plusminus">
-          <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2008-01-01 TO 2008-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
-              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
-          </span>
-          <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2008-01-01 TO 2008-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
-              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
-          </span>
-      </span>
-    </li>
-
-    <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2007-01-01 TO 2007-12-31]?type=edismax&sort=timestamp+desc">2007</a>
-        <span class="plusminus">
-          <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2007-01-01 TO 2007-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
-              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
-          </span>
-          <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2007-01-01 TO 2007-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2013-01-01 TO 2013-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -409,14 +323,42 @@
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2006-01-01 TO 2006-12-31]?type=edismax&sort=timestamp+desc">2006</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2012-01-01 TO 2012-12-31]?type=edismax&sort=timestamp+desc">2012</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2006-01-01 TO 2006-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2012-01-01 TO 2012-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2006-01-01 TO 2006-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2012-01-01 TO 2012-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
+          </span>
+      </span>
+    </li>
+
+    <li role="option">
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2011-01-01 TO 2011-12-31]?type=edismax&sort=timestamp+desc">2011</a>
+        <span class="plusminus">
+          <span class="plus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2011-01-01 TO 2011-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
+          </span>
+          <span class="minus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2011-01-01 TO 2011-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
+          </span>
+      </span>
+    </li>
+
+    <li role="option">
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2010-01-01 TO 2010-12-31]?type=edismax&sort=timestamp+desc">2010</a>
+        <span class="plusminus">
+          <span class="plus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2010-01-01 TO 2010-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
+          </span>
+          <span class="minus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2010-01-01 TO 2010-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -424,14 +366,42 @@
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2005-01-01 TO 2005-12-31]?type=edismax&sort=timestamp+desc">2005</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2009-01-01 TO 2009-12-31]?type=edismax&sort=timestamp+desc">2009</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2005-01-01 TO 2005-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2009-01-01 TO 2009-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2005-01-01 TO 2005-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2009-01-01 TO 2009-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
+          </span>
+      </span>
+    </li>
+
+    <li role="option">
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2008-01-01 TO 2008-12-31]?type=edismax&sort=timestamp+desc">2008</a>
+        <span class="plusminus">
+          <span class="plus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2008-01-01 TO 2008-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
+          </span>
+          <span class="minus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2008-01-01 TO 2008-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
+          </span>
+      </span>
+    </li>
+
+    <li role="option">
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2007-01-01 TO 2007-12-31]?type=edismax&sort=timestamp+desc">2007</a>
+        <span class="plusminus">
+          <span class="plus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2007-01-01 TO 2007-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
+          </span>
+          <span class="minus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2007-01-01 TO 2007-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -439,14 +409,14 @@
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2004-01-01 TO 2004-12-31]?type=edismax&sort=timestamp+desc">2004</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2006-01-01 TO 2006-12-31]?type=edismax&sort=timestamp+desc">2006</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2004-01-01 TO 2004-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2006-01-01 TO 2006-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2004-01-01 TO 2004-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2006-01-01 TO 2006-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -454,14 +424,14 @@
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2003-01-01 TO 2003-12-31]?type=edismax&sort=timestamp+desc">2003</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2005-01-01 TO 2005-12-31]?type=edismax&sort=timestamp+desc">2005</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2003-01-01 TO 2003-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2005-01-01 TO 2005-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2003-01-01 TO 2003-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2005-01-01 TO 2005-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -469,14 +439,14 @@
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2002-01-01 TO 2002-12-31]?type=edismax&sort=timestamp+desc">2002</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2004-01-01 TO 2004-12-31]?type=edismax&sort=timestamp+desc">2004</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2002-01-01 TO 2002-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2004-01-01 TO 2004-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2002-01-01 TO 2002-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2004-01-01 TO 2004-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -484,28 +454,58 @@
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2001-01-01 TO 2001-12-31]?type=edismax&sort=timestamp+desc">2001</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2003-01-01 TO 2003-12-31]?type=edismax&sort=timestamp+desc">2003</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2001-01-01 TO 2001-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2003-01-01 TO 2003-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2001-01-01 TO 2001-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2003-01-01 TO 2003-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
+          </span>
+      </span>
+    </li>
+
+
+    <li role="option">
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2002-01-01 TO 2002-12-31]?type=edismax&sort=timestamp+desc">2002</a>
+        <span class="plusminus">
+          <span class="plus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2002-01-01 TO 2002-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
+          </span>
+          <span class="minus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2002-01-01 TO 2002-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
+          </span>
+      </span>
+    </li>
+
+
+    <li role="option">
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2001-01-01 TO 2001-12-31]?type=edismax&sort=timestamp+desc">2001</a>
+        <span class="plusminus">
+          <span class="plus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2001-01-01 TO 2001-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
+          </span>
+          <span class="minus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2001-01-01 TO 2001-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
     </li>
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01 TO 2000-12-31]?type=edismax&sort=timestamp+desc">2000</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2000-01-01 TO 2000-12-31]?type=edismax&sort=timestamp+desc">2000</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01 TO 2000-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2000-01-01 TO 2000-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01 TO 2000-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2000-01-01 TO 2000-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -516,14 +516,14 @@
 <ul role="listbox" class="islandora-solr-facet">
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/199[0-9].*/?type=edismax&sort=timestamp+desc">1990-1999</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/199[0-9].*/?type=edismax&sort=timestamp+desc">1990-1999</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/199[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/199[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/199[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/199[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -531,42 +531,42 @@
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/198[0-9].*/?type=edismax&sort=timestamp+desc">1980-1989</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/198[0-9].*/?type=edismax&sort=timestamp+desc">1980-1989</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/198[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/198[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/198[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/198[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
     </li>
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/197[0-9].*/?type=edismax&sort=timestamp+desc">1970-1979</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/197[0-9].*/?type=edismax&sort=timestamp+desc">1970-1979</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/197[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/197[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/197[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/197[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
     </li>
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/196[0-9].*/?type=edismax&sort=timestamp+desc">1960-1969</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/196[0-9].*/?type=edismax&sort=timestamp+desc">1960-1969</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/196[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/196[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/196[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/196[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -574,28 +574,28 @@
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/195[0-9].*/?type=edismax&sort=timestamp+desc">1950-1959</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/195[0-9].*/?type=edismax&sort=timestamp+desc">1950-1959</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/195[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/195[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/195[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/195[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
     </li>
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/194[0-9].*/?type=edismax&sort=timestamp+desc">1940-1949</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/194[0-9].*/?type=edismax&sort=timestamp+desc">1940-1949</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/194[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/194[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/194[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/194[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -610,3 +610,4 @@
 
 
 <!-- END islandora-solr-facet.tpl.php -->
+

--- a/files/islandora-solr-facet.tpl.php
+++ b/files/islandora-solr-facet.tpl.php
@@ -1,167 +1,4 @@
 <?php
-/**
- * @file
- * Islandora_solr_metadata display template.
- *
- * Variables available:
- * - $solr_fields: Array of results returned from Solr for the current object
- *   based upon defined display configuration(s). The array structure is:
- *   - display_label: The defined display label corresponding to the Solr field
- *     as defined in the configuration in translatable string form.
- *   - value: An array containing all the result(s) found for the specific field
- *     in Solr for the current object when queried against Solr.
- * - $found: Boolean indicating if a Solr doc was found for the current object.
- * - $not_found_message: A string to print if there was no document found in
- *   Solr.
- *
- * @see template_preprocess_islandora_solr_metadata_display()
- * @see template_process_islandora_solr_metadata_display()
- */
-// find if user has thesis_manager role
-if (in_array('thesis_manager_role', $user->roles)) {
-  $thesis_manager_role = TRUE;
-  // pull in object info
-  $islandora_object=$variables['islandora_object'];
-  // get pid
-  $pid = $islandora_object->id;
-  // get state
-  $state = $islandora_object->state;
-  // get workflow state
-  $wfstate = db_select('trace_workflow_pids', 'q')
-     ->fields('q', array('state'))
-     ->condition('pid', "$pid")
-     ->execute()
-     ->fetchField();
-  if (($state == 'I')&&($wfstate == 's')) {
-    // get owner
-    $ownerid = $islandora_object->owner;
-    // get owner email
-    $ownermail = db_select('users', 'q')
-        ->fields('q', array('mail'))
-        ->condition('name', "$ownerid")
-        ->execute()
-        ->fetchField();
-    // also get thesis_manager email
-    $tm_mail = $user->mail;
-    //
-    $prevmess = FALSE;
-    $messages = '';
-    // detect whether MESSAGES datastream exists
-    if (isset($islandora_object['MESSAGES'])) {
-      $prevmess = TRUE;
-      $messages = $islandora_object->getDatastream('MESSAGES')->content;
-    }
-    //print t("tm role = $thesis_manager_role <br />");
-    //print t("PID = $pid <br />");
-    //print t("state = $state <br />");
-    //print t("owner = $ownerid <br />");
-    //print t("ownermail = $ownermail <br />");
-    $submit = '';
-    $newmess = '';
-    if (isset($_POST['submit'])) $submit = $_POST['submit'];
-    if (isset($_POST['bodytext'])) $bodytext = $_POST['bodytext'];
-    if ($submit == "Send Message") { // process message and ds
-      if ($prevmess) {
-        $newmess = $messages;
-      }
-      $newmess.= "-------------------------------------------------";
-      $newmess.= "FROM: Thesis Manager\n";
-      $newmess.= "TO: $ownermail  CC: $tm_mail\n";
-      $newmess.= "SUBJECT: Message from the Thesis Manager\n";
-      $now = "Date: ".date("Y-m-d H:i:s");
-      $newmess.= "$now \n";
-      $newmess.= "$bodytext \n";
-      // add new MESSAGES ds
-      if (!$prevmess) {
-        $ds = $islandora_object->constructDatastream('MESSAGES', 'M');
-        $ds->label = "messages.txt";
-        $ds->mimetype = "text/plain";
-        $ds->setContentFromString($newmess);
-        $islandora_object->ingestDatastream($ds);
-      } else {
-        $islandora_object['MESSAGES']->setContentFromString("$newmess");
-      }
-      //send email
-      $subject = "Message from the Thesis Manager";
-      $header = "From: ".$tm_mail. "\r\n"; //optional headerfields
-      $to = $ownermail." ".$tm_mail. "\r\n";
-      //$to = "\r\n";
-      if (mail($to, $subject, $bodytext, $header))  {
-        drupal_set_message('The message was sent.');
-      } else {
-        drupal_set_message('There was an error sending the message.');
-      }
-      // clear and reload
-      $bodytext=$submit = '';
-      header("Location: /islandora/object/$pid");
-      exit();
-    } else { // create the form
-      //$starttext = "This is the WRONG standard text.\n";
-      //Replace per TRAC-815
-      $starttext = date("Y-m-d H:i:s");
-      print t("<div>");
-      if ($prevmess) {
-        print l(t('View the Previous Messages'), "islandora/object/$pid/datastream/MESSAGES/view");
-      }else{
-        print t('No Previous Messages');
-      }
-      print t("</div>");
-      print "<div id=\"tm_mail\">\n";
-      print "<b>Email the owner: $ownermail CC: $tm_mail </b><br/>";
-      print "<b>Subject: Message from the Thesis Manager</b> <br />";
-      print "<form action=\"#\" method=\"post\">\n";
-      print '<label for="template_email">Select a template for email</label>';
-      print '<select id="template_email" onchange="myFunction(this.value,\''.$ownerid.'\',\''.$tm_mail.'\')">';
-			print '  <option value="nothing">Simple Date-only Email Template</option>';
-      print '  <option value="more_edits_required">Additional Edits Needed</option>';
-      print '  <option value="accepted_student_submission">Notification of Acceptance</option>';
-      print '</select>';
-      print '<br/>';
-      print "<textarea id=\"email_textarea\"name=\"bodytext\" rows=\"10\" cols=\"100\">$starttext</textarea>\n";
-      print "<br/><input type=\"submit\" name=\"submit\" value=\"Send Message\" />\n";
-      print "</form>\n";
-      print "</div>\n";
-    }// end else
-  } //end if state
-} //end if thesis_manager_role
-// drupal_add_js(array('UTKdrupal' => array('testvar' => $testVariable)), array('type' => 'setting'));
-
-drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js','file');
-?>
-<?php if ($found):
-  if (!(empty($solr_fields) && variable_get('islandora_solr_metadata_omit_empty_values', FALSE))):?>
-<fieldset <?php $print ? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata collapsible"');?>>
-  <legend><span class="fieldset-legend"><?php print t('Details'); ?></span></legend>
-  <div class="fieldset-wrapper">
-    <dl xmlns:dcterms="http://purl.org/dc/terms/" class="islandora-inline-metadata islandora-metadata-fields">
-      <?php $row_field = 0; ?>
-      <?php foreach($solr_fields as $value): ?>
-        <dt class="<?php print $row_field == 0 ? ' first' : ''; ?>">
-          <?php print $value['display_label']; ?>
-        </dt>
-        <dd class="<?php print $row_field == 0 ? ' first' : ''; ?>">
-          <?php print check_markup(implode("\n", $value['value']), 'islandora_solr_metadata_filtered_html'); ?>
-        </dd>
-        <?php $row_field++; ?>
-      <?php endforeach; ?>
-    </dl>
-  </div>
-</fieldset>
-<?php endif; ?>
-<?php else: ?>
-  <fieldset <?php $print ? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata collapsible collapsed"');?>>
-    <legend><span class="fieldset-legend"><?php print t('Details'); ?></span></legend>
-    <?php if (in_array('administrator',$GLOBALS['user']->roles)): ?>
-      <div class="messages--warning messages warning">
-        <?php print $not_found_message; ?>
-      </div>
-    <?php endif; ?>
-  </fieldset>
-<?php endif; ?>
-
-<!-- START SEARCH-BY-DATe -->
-
-<!-- ?php -->
 
 /**
  * @file
@@ -170,7 +7,7 @@ drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js'
  * @TODO document available variables
  */
 // $total_facets = count($buckets);
-<@--  ?  test to see if this php block was the problem-->
+?>
 
 <!-- BEGIN islandora-solr-facet.tpl.php -->
 
@@ -769,7 +606,7 @@ drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js'
 </ul>
 
 
-<!-- END SEARCH-BY-DATE -->
+<!-- END BROWSE-BY-DATE -->
 
 
 <!-- END islandora-solr-facet.tpl.php -->

--- a/files/islandora-solr-metadata-display.tpl.php
+++ b/files/islandora-solr-metadata-display.tpl.php
@@ -1,4 +1,167 @@
 <?php
+/**
+ * @file
+ * Islandora_solr_metadata display template.
+ *
+ * Variables available:
+ * - $solr_fields: Array of results returned from Solr for the current object
+ *   based upon defined display configuration(s). The array structure is:
+ *   - display_label: The defined display label corresponding to the Solr field
+ *     as defined in the configuration in translatable string form.
+ *   - value: An array containing all the result(s) found for the specific field
+ *     in Solr for the current object when queried against Solr.
+ * - $found: Boolean indicating if a Solr doc was found for the current object.
+ * - $not_found_message: A string to print if there was no document found in
+ *   Solr.
+ *
+ * @see template_preprocess_islandora_solr_metadata_display()
+ * @see template_process_islandora_solr_metadata_display()
+ */
+// find if user has thesis_manager role
+if (in_array('thesis_manager_role', $user->roles)) {
+  $thesis_manager_role = TRUE;
+  // pull in object info
+  $islandora_object=$variables['islandora_object'];
+  // get pid
+  $pid = $islandora_object->id;
+  // get state
+  $state = $islandora_object->state;
+  // get workflow state
+  $wfstate = db_select('trace_workflow_pids', 'q')
+     ->fields('q', array('state'))
+     ->condition('pid', "$pid")
+     ->execute()
+     ->fetchField();
+  if (($state == 'I')&&($wfstate == 's')) {
+    // get owner
+    $ownerid = $islandora_object->owner;
+    // get owner email
+    $ownermail = db_select('users', 'q')
+        ->fields('q', array('mail'))
+        ->condition('name', "$ownerid")
+        ->execute()
+        ->fetchField();
+    // also get thesis_manager email
+    $tm_mail = $user->mail;
+    //
+    $prevmess = FALSE;
+    $messages = '';
+    // detect whether MESSAGES datastream exists
+    if (isset($islandora_object['MESSAGES'])) {
+      $prevmess = TRUE;
+      $messages = $islandora_object->getDatastream('MESSAGES')->content;
+    }
+    //print t("tm role = $thesis_manager_role <br />");
+    //print t("PID = $pid <br />");
+    //print t("state = $state <br />");
+    //print t("owner = $ownerid <br />");
+    //print t("ownermail = $ownermail <br />");
+    $submit = '';
+    $newmess = '';
+    if (isset($_POST['submit'])) $submit = $_POST['submit'];
+    if (isset($_POST['bodytext'])) $bodytext = $_POST['bodytext'];
+    if ($submit == "Send Message") { // process message and ds
+      if ($prevmess) {
+        $newmess = $messages;
+      }
+      $newmess.= "-------------------------------------------------";
+      $newmess.= "FROM: Thesis Manager\n";
+      $newmess.= "TO: $ownermail  CC: $tm_mail\n";
+      $newmess.= "SUBJECT: Message from the Thesis Manager\n";
+      $now = "Date: ".date("Y-m-d H:i:s");
+      $newmess.= "$now \n";
+      $newmess.= "$bodytext \n";
+      // add new MESSAGES ds
+      if (!$prevmess) {
+        $ds = $islandora_object->constructDatastream('MESSAGES', 'M');
+        $ds->label = "messages.txt";
+        $ds->mimetype = "text/plain";
+        $ds->setContentFromString($newmess);
+        $islandora_object->ingestDatastream($ds);
+      } else {
+        $islandora_object['MESSAGES']->setContentFromString("$newmess");
+      }
+      //send email
+      $subject = "Message from the Thesis Manager";
+      $header = "From: ".$tm_mail. "\r\n"; //optional headerfields
+      $to = $ownermail." ".$tm_mail. "\r\n";
+      //$to = "\r\n";
+      if (mail($to, $subject, $bodytext, $header))  {
+        drupal_set_message('The message was sent.');
+      } else {
+        drupal_set_message('There was an error sending the message.');
+      }
+      // clear and reload
+      $bodytext=$submit = '';
+      header("Location: /islandora/object/$pid");
+      exit();
+    } else { // create the form
+      //$starttext = "This is the WRONG standard text.\n";
+      //Replace per TRAC-815
+      $starttext = date("Y-m-d H:i:s");
+      print t("<div>");
+      if ($prevmess) {
+        print l(t('View the Previous Messages'), "islandora/object/$pid/datastream/MESSAGES/view");
+      }else{
+        print t('No Previous Messages');
+      }
+      print t("</div>");
+      print "<div id=\"tm_mail\">\n";
+      print "<b>Email the owner: $ownermail CC: $tm_mail </b><br/>";
+      print "<b>Subject: Message from the Thesis Manager</b> <br />";
+      print "<form action=\"#\" method=\"post\">\n";
+      print '<label for="template_email">Select a template for email</label>';
+      print '<select id="template_email" onchange="myFunction(this.value,\''.$ownerid.'\',\''.$tm_mail.'\')">';
+			print '  <option value="nothing">Simple Date-only Email Template</option>';
+      print '  <option value="more_edits_required">Additional Edits Needed</option>';
+      print '  <option value="accepted_student_submission">Notification of Acceptance</option>';
+      print '</select>';
+      print '<br/>';
+      print "<textarea id=\"email_textarea\"name=\"bodytext\" rows=\"10\" cols=\"100\">$starttext</textarea>\n";
+      print "<br/><input type=\"submit\" name=\"submit\" value=\"Send Message\" />\n";
+      print "</form>\n";
+      print "</div>\n";
+    }// end else
+  } //end if state
+} //end if thesis_manager_role
+// drupal_add_js(array('UTKdrupal' => array('testvar' => $testVariable)), array('type' => 'setting'));
+
+drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js','file');
+?>
+<?php if ($found):
+  if (!(empty($solr_fields) && variable_get('islandora_solr_metadata_omit_empty_values', FALSE))):?>
+<fieldset <?php $print ? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata collapsible"');?>>
+  <legend><span class="fieldset-legend"><?php print t('Details'); ?></span></legend>
+  <div class="fieldset-wrapper">
+    <dl xmlns:dcterms="http://purl.org/dc/terms/" class="islandora-inline-metadata islandora-metadata-fields">
+      <?php $row_field = 0; ?>
+      <?php foreach($solr_fields as $value): ?>
+        <dt class="<?php print $row_field == 0 ? ' first' : ''; ?>">
+          <?php print $value['display_label']; ?>
+        </dt>
+        <dd class="<?php print $row_field == 0 ? ' first' : ''; ?>">
+          <?php print check_markup(implode("\n", $value['value']), 'islandora_solr_metadata_filtered_html'); ?>
+        </dd>
+        <?php $row_field++; ?>
+      <?php endforeach; ?>
+    </dl>
+  </div>
+</fieldset>
+<?php endif; ?>
+<?php else: ?>
+  <fieldset <?php $print ? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata collapsible collapsed"');?>>
+    <legend><span class="fieldset-legend"><?php print t('Details'); ?></span></legend>
+    <?php if (in_array('administrator',$GLOBALS['user']->roles)): ?>
+      <div class="messages--warning messages warning">
+        <?php print $not_found_message; ?>
+      </div>
+    <?php endif; ?>
+  </fieldset>
+<?php endif; ?>
+
+<!-- START SEARCH-BY-DATe -->
+
+<!-- ?php -->
 
 /**
  * @file
@@ -7,7 +170,7 @@
  * @TODO document available variables
  */
 // $total_facets = count($buckets);
-?>
+<@--  ?  test to see if this php block was the problem-->
 
 <!-- BEGIN islandora-solr-facet.tpl.php -->
 
@@ -606,7 +769,7 @@
 </ul>
 
 
-<!-- END BROWSE-BY-DATE -->
+<!-- END SEARCH-BY-DATE -->
 
 
-<!-- END islandora-solr-facet.tpl.php -->
+<!-- END islandora-solr-metadata-display.tpl.php -->

--- a/files/islandora-solr-metadata-display.tpl.php
+++ b/files/islandora-solr-metadata-display.tpl.php
@@ -1,167 +1,4 @@
 <?php
-/**
- * @file
- * Islandora_solr_metadata display template.
- *
- * Variables available:
- * - $solr_fields: Array of results returned from Solr for the current object
- *   based upon defined display configuration(s). The array structure is:
- *   - display_label: The defined display label corresponding to the Solr field
- *     as defined in the configuration in translatable string form.
- *   - value: An array containing all the result(s) found for the specific field
- *     in Solr for the current object when queried against Solr.
- * - $found: Boolean indicating if a Solr doc was found for the current object.
- * - $not_found_message: A string to print if there was no document found in
- *   Solr.
- *
- * @see template_preprocess_islandora_solr_metadata_display()
- * @see template_process_islandora_solr_metadata_display()
- */
-// find if user has thesis_manager role
-if (in_array('thesis_manager_role', $user->roles)) {
-  $thesis_manager_role = TRUE;
-  // pull in object info
-  $islandora_object=$variables['islandora_object'];
-  // get pid
-  $pid = $islandora_object->id;
-  // get state
-  $state = $islandora_object->state;
-  // get workflow state
-  $wfstate = db_select('trace_workflow_pids', 'q')
-     ->fields('q', array('state'))
-     ->condition('pid', "$pid")
-     ->execute()
-     ->fetchField();
-  if (($state == 'I')&&($wfstate == 's')) {
-    // get owner
-    $ownerid = $islandora_object->owner;
-    // get owner email
-    $ownermail = db_select('users', 'q')
-        ->fields('q', array('mail'))
-        ->condition('name', "$ownerid")
-        ->execute()
-        ->fetchField();
-    // also get thesis_manager email
-    $tm_mail = $user->mail;
-    //
-    $prevmess = FALSE;
-    $messages = '';
-    // detect whether MESSAGES datastream exists
-    if (isset($islandora_object['MESSAGES'])) {
-      $prevmess = TRUE;
-      $messages = $islandora_object->getDatastream('MESSAGES')->content;
-    }
-    //print t("tm role = $thesis_manager_role <br />");
-    //print t("PID = $pid <br />");
-    //print t("state = $state <br />");
-    //print t("owner = $ownerid <br />");
-    //print t("ownermail = $ownermail <br />");
-    $submit = '';
-    $newmess = '';
-    if (isset($_POST['submit'])) $submit = $_POST['submit'];
-    if (isset($_POST['bodytext'])) $bodytext = $_POST['bodytext'];
-    if ($submit == "Send Message") { // process message and ds
-      if ($prevmess) {
-        $newmess = $messages;
-      }
-      $newmess.= "-------------------------------------------------";
-      $newmess.= "FROM: Thesis Manager\n";
-      $newmess.= "TO: $ownermail  CC: $tm_mail\n";
-      $newmess.= "SUBJECT: Message from the Thesis Manager\n";
-      $now = "Date: ".date("Y-m-d H:i:s");
-      $newmess.= "$now \n";
-      $newmess.= "$bodytext \n";
-      // add new MESSAGES ds
-      if (!$prevmess) {
-        $ds = $islandora_object->constructDatastream('MESSAGES', 'M');
-        $ds->label = "messages.txt";
-        $ds->mimetype = "text/plain";
-        $ds->setContentFromString($newmess);
-        $islandora_object->ingestDatastream($ds);
-      } else {
-        $islandora_object['MESSAGES']->setContentFromString("$newmess");
-      }
-      //send email
-      $subject = "Message from the Thesis Manager";
-      $header = "From: ".$tm_mail. "\r\n"; //optional headerfields
-      $to = $ownermail." ".$tm_mail. "\r\n";
-      //$to = "\r\n";
-      if (mail($to, $subject, $bodytext, $header))  {
-        drupal_set_message('The message was sent.');
-      } else {
-        drupal_set_message('There was an error sending the message.');
-      }
-      // clear and reload
-      $bodytext=$submit = '';
-      header("Location: /islandora/object/$pid");
-      exit();
-    } else { // create the form
-      //$starttext = "This is the WRONG standard text.\n";
-      //Replace per TRAC-815
-      $starttext = date("Y-m-d H:i:s");
-      print t("<div>");
-      if ($prevmess) {
-        print l(t('View the Previous Messages'), "islandora/object/$pid/datastream/MESSAGES/view");
-      }else{
-        print t('No Previous Messages');
-      }
-      print t("</div>");
-      print "<div id=\"tm_mail\">\n";
-      print "<b>Email the owner: $ownermail CC: $tm_mail </b><br/>";
-      print "<b>Subject: Message from the Thesis Manager</b> <br />";
-      print "<form action=\"#\" method=\"post\">\n";
-      print '<label for="template_email">Select a template for email</label>';
-      print '<select id="template_email" onchange="myFunction(this.value,\''.$ownerid.'\',\''.$tm_mail.'\')">';
-			print '  <option value="nothing">Simple Date-only Email Template</option>';
-      print '  <option value="more_edits_required">Additional Edits Needed</option>';
-      print '  <option value="accepted_student_submission">Notification of Acceptance</option>';
-      print '</select>';
-      print '<br/>';
-      print "<textarea id=\"email_textarea\"name=\"bodytext\" rows=\"10\" cols=\"100\">$starttext</textarea>\n";
-      print "<br/><input type=\"submit\" name=\"submit\" value=\"Send Message\" />\n";
-      print "</form>\n";
-      print "</div>\n";
-    }// end else
-  } //end if state
-} //end if thesis_manager_role
-// drupal_add_js(array('UTKdrupal' => array('testvar' => $testVariable)), array('type' => 'setting'));
-
-drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js','file');
-?>
-<?php if ($found):
-  if (!(empty($solr_fields) && variable_get('islandora_solr_metadata_omit_empty_values', FALSE))):?>
-<fieldset <?php $print ? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata collapsible"');?>>
-  <legend><span class="fieldset-legend"><?php print t('Details'); ?></span></legend>
-  <div class="fieldset-wrapper">
-    <dl xmlns:dcterms="http://purl.org/dc/terms/" class="islandora-inline-metadata islandora-metadata-fields">
-      <?php $row_field = 0; ?>
-      <?php foreach($solr_fields as $value): ?>
-        <dt class="<?php print $row_field == 0 ? ' first' : ''; ?>">
-          <?php print $value['display_label']; ?>
-        </dt>
-        <dd class="<?php print $row_field == 0 ? ' first' : ''; ?>">
-          <?php print check_markup(implode("\n", $value['value']), 'islandora_solr_metadata_filtered_html'); ?>
-        </dd>
-        <?php $row_field++; ?>
-      <?php endforeach; ?>
-    </dl>
-  </div>
-</fieldset>
-<?php endif; ?>
-<?php else: ?>
-  <fieldset <?php $print ? print('class="islandora islandora-metadata"') : print('class="islandora islandora-metadata collapsible collapsed"');?>>
-    <legend><span class="fieldset-legend"><?php print t('Details'); ?></span></legend>
-    <?php if (in_array('administrator',$GLOBALS['user']->roles)): ?>
-      <div class="messages--warning messages warning">
-        <?php print $not_found_message; ?>
-      </div>
-    <?php endif; ?>
-  </fieldset>
-<?php endif; ?>
-
-<!-- START SEARCH-BY-DATe -->
-
-<!-- ?php -->
 
 /**
  * @file
@@ -170,7 +7,7 @@ drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js'
  * @TODO document available variables
  */
 // $total_facets = count($buckets);
-<@--  ?  test to see if this php block was the problem-->
+?>
 
 <!-- BEGIN islandora-solr-facet.tpl.php -->
 
@@ -399,43 +236,28 @@ drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js'
 <ul role="listbox" class="islandora-solr-facet">
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2018-01-01 TO 2018-12-31]?type=edismax&sort=timestamp+desc">2018</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2018-01-01 TO 2018-12-31]?type=edismax&sort=timestamp+desc">2018</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2018-01-01 TO 2018-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2018-01-01 TO 2018-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2018-01-01 TO 2018-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2018-01-01 TO 2018-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
     </li>
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2017-01-01 TO 2017-12-31]?type=edismax&sort=timestamp+desc">2017</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2017-01-01 TO 2017-12-31]?type=edismax&sort=timestamp+desc">2017</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2017-01-01 TO 2017-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2017-01-01 TO 2017-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2017-01-01 TO 2017-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
-              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
-          </span>
-      </span>
-    </li>
-
-
-    <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2016-01-01 TO 2016-12-31]?type=edismax&sort=timestamp+desc">2016</a>
-        <span class="plusminus">
-          <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2016-01-01 TO 2016-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
-              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
-          </span>
-          <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2016-01-01 TO 2016-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2017-01-01 TO 2017-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -443,42 +265,14 @@ drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js'
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2015-01-01 TO 2015-12-31]?type=edismax&sort=timestamp+desc">2015</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2016-01-01 TO 2016-12-31]?type=edismax&sort=timestamp+desc">2016</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2015-01-01 TO 2015-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2016-01-01 TO 2016-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2015-01-01 TO 2015-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
-              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
-          </span>
-      </span>
-    </li>
-
-    <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2014-01-01 TO 2014-12-31]?type=edismax&sort=timestamp+desc">2014</a>
-        <span class="plusminus">
-          <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2014-01-01 TO 2014-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
-              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
-          </span>
-          <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2014-01-01 TO 2014-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
-              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
-          </span>
-      </span>
-    </li>
-
-    <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2013-01-01 TO 2013-12-31]?type=edismax&sort=timestamp+desc">2013</a>
-        <span class="plusminus">
-          <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2013-01-01 TO 2013-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
-              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
-          </span>
-          <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2013-01-01 TO 2013-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2016-01-01 TO 2016-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -486,85 +280,42 @@ drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js'
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2012-01-01 TO 2012-12-31]?type=edismax&sort=timestamp+desc">2012</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2015-01-01 TO 2015-12-31]?type=edismax&sort=timestamp+desc">2015</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2012-01-01 TO 2012-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2015-01-01 TO 2015-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2012-01-01 TO 2012-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2015-01-01 TO 2015-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
     </li>
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2011-01-01 TO 2011-12-31]?type=edismax&sort=timestamp+desc">2011</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2014-01-01 TO 2014-12-31]?type=edismax&sort=timestamp+desc">2014</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2011-01-01 TO 2011-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2014-01-01 TO 2014-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2011-01-01 TO 2011-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2014-01-01 TO 2014-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
     </li>
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2010-01-01 TO 2010-12-31]?type=edismax&sort=timestamp+desc">2010</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2013-01-01 TO 2013-12-31]?type=edismax&sort=timestamp+desc">2013</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2010-01-01 TO 2010-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2013-01-01 TO 2013-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2010-01-01 TO 2010-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
-              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
-          </span>
-      </span>
-    </li>
-
-
-    <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2009-01-01 TO 2009-12-31]?type=edismax&sort=timestamp+desc">2009</a>
-        <span class="plusminus">
-          <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2009-01-01 TO 2009-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
-              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
-          </span>
-          <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2009-01-01 TO 2009-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
-              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
-          </span>
-      </span>
-    </li>
-
-    <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2008-01-01 TO 2008-12-31]?type=edismax&sort=timestamp+desc">2008</a>
-        <span class="plusminus">
-          <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2008-01-01 TO 2008-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
-              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
-          </span>
-          <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2008-01-01 TO 2008-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
-              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
-          </span>
-      </span>
-    </li>
-
-    <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2007-01-01 TO 2007-12-31]?type=edismax&sort=timestamp+desc">2007</a>
-        <span class="plusminus">
-          <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2007-01-01 TO 2007-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
-              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
-          </span>
-          <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2007-01-01 TO 2007-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2013-01-01 TO 2013-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -572,14 +323,42 @@ drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js'
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2006-01-01 TO 2006-12-31]?type=edismax&sort=timestamp+desc">2006</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2012-01-01 TO 2012-12-31]?type=edismax&sort=timestamp+desc">2012</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2006-01-01 TO 2006-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2012-01-01 TO 2012-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2006-01-01 TO 2006-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2012-01-01 TO 2012-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
+          </span>
+      </span>
+    </li>
+
+    <li role="option">
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2011-01-01 TO 2011-12-31]?type=edismax&sort=timestamp+desc">2011</a>
+        <span class="plusminus">
+          <span class="plus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2011-01-01 TO 2011-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
+          </span>
+          <span class="minus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2011-01-01 TO 2011-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
+          </span>
+      </span>
+    </li>
+
+    <li role="option">
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2010-01-01 TO 2010-12-31]?type=edismax&sort=timestamp+desc">2010</a>
+        <span class="plusminus">
+          <span class="plus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2010-01-01 TO 2010-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
+          </span>
+          <span class="minus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2010-01-01 TO 2010-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -587,14 +366,42 @@ drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js'
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2005-01-01 TO 2005-12-31]?type=edismax&sort=timestamp+desc">2005</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2009-01-01 TO 2009-12-31]?type=edismax&sort=timestamp+desc">2009</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2005-01-01 TO 2005-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2009-01-01 TO 2009-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2005-01-01 TO 2005-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2009-01-01 TO 2009-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
+          </span>
+      </span>
+    </li>
+
+    <li role="option">
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2008-01-01 TO 2008-12-31]?type=edismax&sort=timestamp+desc">2008</a>
+        <span class="plusminus">
+          <span class="plus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2008-01-01 TO 2008-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
+          </span>
+          <span class="minus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2008-01-01 TO 2008-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
+          </span>
+      </span>
+    </li>
+
+    <li role="option">
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2007-01-01 TO 2007-12-31]?type=edismax&sort=timestamp+desc">2007</a>
+        <span class="plusminus">
+          <span class="plus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2007-01-01 TO 2007-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
+          </span>
+          <span class="minus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2007-01-01 TO 2007-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -602,14 +409,14 @@ drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js'
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2004-01-01 TO 2004-12-31]?type=edismax&sort=timestamp+desc">2004</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2006-01-01 TO 2006-12-31]?type=edismax&sort=timestamp+desc">2006</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2004-01-01 TO 2004-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2006-01-01 TO 2006-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2004-01-01 TO 2004-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2006-01-01 TO 2006-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -617,14 +424,14 @@ drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js'
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2003-01-01 TO 2003-12-31]?type=edismax&sort=timestamp+desc">2003</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2005-01-01 TO 2005-12-31]?type=edismax&sort=timestamp+desc">2005</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2003-01-01 TO 2003-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2005-01-01 TO 2005-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2003-01-01 TO 2003-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2005-01-01 TO 2005-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -632,14 +439,14 @@ drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js'
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2002-01-01 TO 2002-12-31]?type=edismax&sort=timestamp+desc">2002</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2004-01-01 TO 2004-12-31]?type=edismax&sort=timestamp+desc">2004</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2002-01-01 TO 2002-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2004-01-01 TO 2004-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2002-01-01 TO 2002-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2004-01-01 TO 2004-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -647,28 +454,58 @@ drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js'
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2001-01-01 TO 2001-12-31]?type=edismax&sort=timestamp+desc">2001</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2003-01-01 TO 2003-12-31]?type=edismax&sort=timestamp+desc">2003</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2001-01-01 TO 2001-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2003-01-01 TO 2003-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2001-01-01 TO 2001-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2003-01-01 TO 2003-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
+          </span>
+      </span>
+    </li>
+
+
+    <li role="option">
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2002-01-01 TO 2002-12-31]?type=edismax&sort=timestamp+desc">2002</a>
+        <span class="plusminus">
+          <span class="plus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2002-01-01 TO 2002-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
+          </span>
+          <span class="minus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2002-01-01 TO 2002-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
+          </span>
+      </span>
+    </li>
+
+
+    <li role="option">
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2001-01-01 TO 2001-12-31]?type=edismax&sort=timestamp+desc">2001</a>
+        <span class="plusminus">
+          <span class="plus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2001-01-01 TO 2001-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
+          </span>
+          <span class="minus_facet">
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2001-01-01 TO 2001-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
     </li>
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01 TO 2000-12-31]?type=edismax&sort=timestamp+desc">2000</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2000-01-01 TO 2000-12-31]?type=edismax&sort=timestamp+desc">2000</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01 TO 2000-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2000-01-01 TO 2000-12-31]?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01 TO 2000-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt%3A[2000-01-01 TO 2000-12-31]?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -679,14 +516,14 @@ drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js'
 <ul role="listbox" class="islandora-solr-facet">
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/199[0-9].*/?type=edismax&sort=timestamp+desc">1990-1999</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/199[0-9].*/?type=edismax&sort=timestamp+desc">1990-1999</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/199[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/199[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/199[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/199[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -694,42 +531,42 @@ drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js'
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/198[0-9].*/?type=edismax&sort=timestamp+desc">1980-1989</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/198[0-9].*/?type=edismax&sort=timestamp+desc">1980-1989</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/198[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/198[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/198[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/198[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
     </li>
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/197[0-9].*/?type=edismax&sort=timestamp+desc">1970-1979</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/197[0-9].*/?type=edismax&sort=timestamp+desc">1970-1979</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/197[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/197[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/197[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/197[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
     </li>
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/196[0-9].*/?type=edismax&sort=timestamp+desc">1960-1969</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/196[0-9].*/?type=edismax&sort=timestamp+desc">1960-1969</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/196[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/196[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/196[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/196[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -737,28 +574,28 @@ drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js'
 
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/195[0-9].*/?type=edismax&sort=timestamp+desc">1950-1959</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/195[0-9].*/?type=edismax&sort=timestamp+desc">1950-1959</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/195[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/195[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/195[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/195[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
     </li>
 
     <li role="option">
-        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/194[0-9].*/?type=edismax&sort=timestamp+desc">1940-1949</a>
+        <a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/194[0-9].*/?type=edismax&sort=timestamp+desc">1940-1949</a>
         <span class="plusminus">
           <span class="plus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/194[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/194[0-9].*/?type=edismax&sort=timestamp+desc" class="plus">+</a>
               <span role="tooltip" name="tooltipTextPlusText" aria-hidden="true" class="tooltiptext_plus">Contains this</span>
           </span>
           <span class="minus_facet">
-              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/194[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
+              <a rel="nofollow" href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt/194[0-9].*/?type=edismax&sort=timestamp+desc" class="minus">-</a>
               <span role="tooltip" name="tooltipTextMinusTest" aria-hidden="true" class="tooltiptext_minus">Excludes this</span>
           </span>
       </span>
@@ -769,7 +606,7 @@ drupal_add_js(drupal_get_path('theme', 'UTKdrupal') .'/js/email_etd_feedback.js'
 </ul>
 
 
-<!-- END SEARCH-BY-DATE -->
+<!-- END BROWSE-BY-DATE -->
 
 
 <!-- END islandora-solr-facet.tpl.php -->

--- a/scripts/custom_scripts/163_revise_email_templates.sh
+++ b/scripts/custom_scripts/163_revise_email_templates.sh
@@ -17,5 +17,6 @@ echo "163_revise_email_templates: Replacing the file: islandora-solr-metadata-di
 
 echo "per TRAC-815"
 
-sudo cp /vagrant/files/islandora-solr-metadata-display.tpl.php  "$DRUPAL_HOME"/sites/all/themes/UTKdrupal/templates/
+sudo cp /vagrant/files/islandora-solr-metadata-display.tpl.php "$DRUPAL_HOME"/sites/all/themes/UTKdrupal/templates/
 
+echo "163_revise_email_templates.sh complete"

--- a/scripts/custom_scripts/164_revise_facet_template_for_date.sh
+++ b/scripts/custom_scripts/164_revise_facet_template_for_date.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+#164_revise_facet_template_for_date.sh
+#all changes needed to revise search-by-date facet
+
+
+####################################################################
+# Per Trac-1022 : Support Google Scholar Request for Inclusion Form: Create the Year-Index.htm page for trace.utk.edu
+# cdeane April 11, 2018
+#
+# adding a block of date search queries to the UTKdrupal/template
+# islandora-solr-facet.tpl.php
+
+echo "164_revise_facet_template_for islandora-solr-facet.tpl.php_date."
+echo "164 Replacing the file: islandora-solr-facet.tpl.php"
+echo "per TRAC-1022"
+
+
+sudo cp /vagrant/files/islandora-solr-facet.tpl.php  "$DRUPAL_HOME"/sites/all/themes/UTKdrupal/templates/
+
+
+echo "164_revise_facet_template_for_date.sh complete"
+
+####################################################################
+

--- a/scripts/custom_scripts/165_revise_metadata-display_template_for_date.sh
+++ b/scripts/custom_scripts/165_revise_metadata-display_template_for_date.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+#165_revise_metadata-display_template_for_date.sh
+#all changes needed to revise search-by-date facet
+
+
+####################################################################
+# Per Trac-1022 : Support Google Scholar Request for Inclusion Form: Create the Year-Index.htm page for trace.utk.edu
+# cdeane April 11, 2018
+#
+# adding a block of date search queries to the UTKdrupal/template
+# islandora-solr-facet.tpl.php
+
+echo "164_revise_facet_template_for islandora-solr-facet.tpl.php_date."
+echo "165_revise_metadata-display_template_for islanodora-solr-metadata-display.tpl.php. "
+
+echo "165 Replacing the file: islandora-solr-metadata-display.tpl.php"
+echo "per TRAC-1022"
+
+
+sudo cp /vagrant/files/islandora-solr-metadata-display.tpl.php  "$DRUPAL_HOME"/sites/all/themes/UTKdrupal/templates/
+
+
+echo "164_revise_facet_template_for_date.sh complete"
+
+####################################################################
+

--- a/scripts/custom_scripts/create_pages.php
+++ b/scripts/custom_scripts/create_pages.php
@@ -532,6 +532,7 @@ add_menu_link_to_trace_navigation($browse_nid, "trace-navigation", "Browse Colle
 $help_nid = create_named_page("help", "Help", "$help_body");
 add_menu_link_to_trace_navigation($help_nid, "trace-navigation", "Help", 4);
 
+
 $policy_nid = create_named_page("policy", "Policy", "$policy_body");
 // add_menu_link_to_trace_navigation($policy_nid, "trace-navigation", "Policy", 5);
 

--- a/scripts/custom_scripts/create_pages.php
+++ b/scripts/custom_scripts/create_pages.php
@@ -70,6 +70,9 @@ $home_body =  <<<HOME_BODY
                 <li>
                     Preserve your work long-term.
                 </li>
+		<li>
+		    <a href="http://localhost:8000/iby">Find latest publications! Search by date across all Collections.</a>
+		</li>
             </ul>
 HOME_BODY;
 
@@ -519,6 +522,71 @@ $privacy_policy_body = <<<PRIVACY_BODY
 </div>
 
 PRIVACY_BODY;
+
+$iby_body = <<<IBY_BODY
+<h4>World readable Search-by-date page</h4>
+Developer test searches
+<ul>
+<li><a href="/islandora/search/timestamp%3A[NOW-10MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 10 minutes</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-20MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 20 minutes</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-30MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 30 minutes</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-60MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 60 minutes</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-2HOURS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 hours</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-12HOURS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 12 hours</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-1DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 1 days</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-2DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 days</a></li>
+</ul>
+
+Search most recent contributions.
+<ul>
+<li><a href="/islandora/search/timestamp%3A[NOW-14DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 weeks</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-28DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 4 weeks</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-62DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 months</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-92DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 3 months</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-183DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 6 months</a></li>
+</ul>
+<p>
+Search one year at a time.
+<ul>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2018-01-01 TO 2018-12-31]?type=edismax&sort=timestamp+desc">2018</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2017-01-01 TO 2017-12-31]?type=edismax&sort=timestamp+desc">2017</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2016-01-01 TO 2016-12-31]?type=edismax&sort=timestamp+desc">2016</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2015-01-01 TO 2015-12-31]?type=edismax&sort=timestamp+desc">2015</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2014-01-01 TO 2014-12-31]?type=edismax&sort=timestamp+desc">2014</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2013-01-01 TO 2013-12-31]?type=edismax&sort=timestamp+desc">2013</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2012-01-01 TO 2012-12-31]?type=edismax&sort=timestamp+desc">2012</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2011-01-01 TO 2011-12-31]?type=edismax&sort=timestamp+desc">2011</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2010-01-01 TO 2010-12-31]?type=edismax&sort=timestamp+desc">2010</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2009-01-01 TO 2009-12-31]?type=edismax&sort=timestamp+desc">2009</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2008-01-01 TO 2008-12-31]?type=edismax&sort=timestamp+desc">2008</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2007-01-01 TO 2007-12-31]?type=edismax&sort=timestamp+desc">2007</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2006-01-01 TO 2006-12-31]?type=edismax&sort=timestamp+desc">2006</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2005-01-01 TO 2005-12-31]?type=edismax&sort=timestamp+desc">2005</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2004-01-01 TO 2004-12-31]?type=edismax&sort=timestamp+desc">2004</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2003-01-01 TO 2003-12-31]?type=edismax&sort=timestamp+desc">2003</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2002-01-01 TO 2002-12-31]?type=edismax&sort=timestamp+desc">2002</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2001-01-01 TO 2001-12-31]?type=edismax&sort=timestamp+desc">2001</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01 TO 2000-12-31]?type=edismax&sort=timestamp+desc">2000</a></li>
+</ul>
+<p>
+Search one decade at a time.
+<ul>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/199[0-9].*/?type=edismax&sort=timestamp+desc">1990-1999</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/198[0-9].*/?type=edismax&sort=timestamp+desc">1980-1989</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/197[0-9].*/?type=edismax&sort=timestamp+desc">1970-1979</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/196[0-9].*/?type=edismax&sort=timestamp+desc">1960-1969</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/195[0-9].*/?type=edismax&sort=timestamp+desc">1950-1959</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/194[0-9].*/?type=edismax&sort=timestamp+desc">1940-1949</a></li>
+
+</ul>
+
+
+IBY_BODY;
+
+
+$iby_nid = create_named_page("iby","Search-by-date","$iby_body");
+//add_menu_link_to_trace_navigation($iby_nid, "trace-navigation", "Search-by-date", 9);
+
 
 $home_nid = create_named_page("home", "Welcome to TRACE", $home_body);
 add_menu_link_to_trace_navigation($home_nid, "trace-navigation", "Home", 1);


### PR DESCRIPTION
** JIRA Ticket**:  
https://jira.lib.utk.edu/browse/TRAC-1022 [finding trace.utk.edu items with Google Scholar]
https://jira.lib.utk.edu/browse/TRAC-1029 [Create the Year-Index.htm page for trace.utk.edu]

* Other Relevant Link
https://scholar.google.com/intl/en/scholar/inclusion.html

# What does this Pull Request do?
This pull request creates a world-readable search-by-date page for Google Scholoar Inclusion.

# The files to be pulled are:

NEW:      /vagrant/files/islandora-solr-facet.tpl.php
REVISE:  /vagrant/files/islandora-solr-metadata-display.tpl.php

REVISE:  /vagrant/scripts/custom_scripts/163_revise_email_templates.sh  
NEW:      /vagrant/scripts/custom_scripts/164_revise_facet_template_for_date.sh
NEW:      /vagrant/scripts/custom_scripts/165_revise_metadata-display_template_for_date.sh

REVISE: /vagrant/scripts/custom_scripts/create_pages.php
                This was the most extensive revision.
               a. add IBY_BODY  code to build the HTML file presented for Google Scholar Inclusion
               b. revise HOME_BODY code to create the link (http://localhost:8000/iby) to give access to the IBY_BODY page.

# Purpose of this pull resuest:

Google Scholar Inclusion requires a world readable Search-by-date page that has links to 
  Search all collections by year.
  Search all collections for most recent two weeks.
  These requirements are met by the page http://localhost:8000/iby

All of the searches described below search the field:  mods_originInfo_encoding_edtf_keyDate_yes_dateModified_dt

If you think another field is better, we need to have the discussion immediately.

Google Scholar Inclusion requires a world readable Search-by-date page that has links to 
  Search all collections by year.
  Search all collections for most recent two weeks.
  These requirements are met by the page http://localhost:8000/iby which will become http://trace.utk.edu/iby

Adding the search-by-date facets in search results makes the site easier for users.

# How should this be tested?

The only Collection that works for submission on vagrant is Graduate Theses and Dissertations.

1. Checkout Trace(TRAC-1029a), do vagrant up.

2. On the home page, click on the link: "Find latest publications! Search by date across all collections."
   -- This should take you to:  http://localhost:8000/iby 
   -- If not, contact me immediately.  We have to deliver this for Google Scholar Inclusion.

3.  Add an etd by userA 
     Make sure the Date of Award is ***IN THE PAST*** or else the etd will not be seen in the collection until after the future date of award.
     SUBMIT.  LOGOUT.

     LOGIN as thesis_manager, accept, publish.

     LOG OUT and become a non-authenticated user because these searches are supposed to be World-Readable.

4.   Go back to localhost:8000/iby
     Search on "Last 10 minutes"
     This should return the etd userA just added. 

5.   Return to Browse Collections, Graduate Theses and Dissertations.
      Enter a YEAR into the Search Repository text box.
      This should bring up the date facets.
      (Searching on non-date terms will not bring up date facets.)
      From the date facets list, click on "Last 10 minutes".
      This should return the etd userA just added. 

Thank you for testing my pull request.

# Interested parties
@DonRichards 
@CanOfBees 
@utkdigitalinitiatives/digital-initiatives-developers
