### PR TITLE
Trac 1029e

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # TRACE [![Build Status](https://travis-ci.org/utkdigitalinitiatives/TRACE.svg?branch=master)](https://travis-ci.org/utkdigitalinitiatives/TRACE)
 <description>Trace is a University of Tennessee digital archive that showcases and preserves published and unpublished works by faculty, departments, programs, research ...</description>
 
+TRAC-1029e to install code to satisfy JIRA Ticket TRAC-1029.
+
 What is the Institutional Repository Project?
 
 The Libraries is currently investigating open source IR systems with the intention to select and implement a new institutional repository platform to replace the hosted Bepress Digtial Commons instance of Trace.

--- a/scripts/custom_scripts/create_pages.php
+++ b/scripts/custom_scripts/create_pages.php
@@ -525,51 +525,38 @@ PRIVACY_BODY;
 
 $iby_body = <<<IBY_BODY
 <h4>World readable Search-by-date page</h4>
-Developer test searches
-<ul>
-<li><a href="/islandora/search/timestamp:[NOW-10MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 10 minutes</a></li>
-<li><a href="/islandora/search/timestamp:[NOW-20MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 20 minutes</a></li>
-<li><a href="/islandora/search/timestamp:[NOW-30MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 30 minutes</a></li>
-<li><a href="/islandora/search/timestamp:[NOW-60MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 60 minutes</a></li>
-<li><a href="/islandora/search/timestamp:[NOW-2HOURS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 hours</a></li>
-<li><a href="/islandora/search/timestamp:[NOW-12HOURS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 12 hours</a></li>
-<li><a href="/islandora/search/timestamp:[NOW-1DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 1 days</a></li>
-<li><a href="/islandora/search/timestamp:[NOW-2DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 days</a></li>
-</ul>
-
 Search most recent contributions.
 <ul>
-<li><a href="/islandora/search/timestamp:[NOW-14DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 weeks</a></li>
-<li><a href="/islandora/search/timestamp:[NOW-28DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 4 weeks</a></li>
-<li><a href="/islandora/search/timestamp:[NOW-62DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 months</a></li>
-<li><a href="/islandora/search/timestamp:[NOW-92DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 3 months</a></li>
-<li><a href="/islandora/search/timestamp:[NOW-183DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 6 months</a></li>
+<li><a href="/islandora/search/timestamp:[NOW-14DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 weeks timestamp</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[NOW-14DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 weeks dateIssued</a></li>
+<li><a href="/islandora/search/timestamp:[NOW-183DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 6 months timestamp</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[NOW-183DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 6 months dateIssued</a></li>
 </ul>
 <p>
 Search one year at a time.
 <ul>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2018-01-01T00:00:00Z TO 2018-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2018</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2017-01-01T00:00:00Z TO 2017-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2017</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2016-01-01T00:00:00Z TO 2016-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2016</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2015-01-01T00:00:00Z TO 2015-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2015</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2014-01-01T00:00:00Z TO 2014-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2014</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2013-01-01T00:00:00Z TO 2013-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2013</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2012-01-01T00:00:00Z TO 2012-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2012</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2011-01-01T00:00:00Z TO 2011-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2011</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2010-01-01T00:00:00Z TO 2010-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2010</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2009-01-01T00:00:00Z TO 2009-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2009</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2008-01-01T00:00:00Z TO 2008-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2008</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2007-01-01T00:00:00Z TO 2007-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2007</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2006-01-01T00:00:00Z TO 2006-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2006</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2005-01-01T00:00:00Z TO 2005-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2005</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2004-01-01T00:00:00Z TO 2004-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2004</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2003-01-01T00:00:00Z TO 2003-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2003</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2002-01-01T00:00:00Z TO 2002-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2002</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2001-01-01T00:00:00Z TO 2001-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2001</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2000-01-01T00:00:00Z TO 2000-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2000</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2018-01-01T00:00:00Z TO 2018-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2018</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2017-01-01T00:00:00Z TO 2017-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2017</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2016-01-01T00:00:00Z TO 2016-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2016</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2015-01-01T00:00:00Z TO 2015-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2015</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2014-01-01T00:00:00Z TO 2014-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2014</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2013-01-01T00:00:00Z TO 2013-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2013</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2012-01-01T00:00:00Z TO 2012-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2012</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2011-01-01T00:00:00Z TO 2011-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2011</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2010-01-01T00:00:00Z TO 2010-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2010</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2009-01-01T00:00:00Z TO 2009-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2009</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2008-01-01T00:00:00Z TO 2008-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2008</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2007-01-01T00:00:00Z TO 2007-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2007</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2006-01-01T00:00:00Z TO 2006-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2006</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2005-01-01T00:00:00Z TO 2005-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2005</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2004-01-01T00:00:00Z TO 2004-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2004</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2003-01-01T00:00:00Z TO 2003-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2003</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2002-01-01T00:00:00Z TO 2002-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2002</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2001-01-01T00:00:00Z TO 2001-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2001</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2000-01-01T00:00:00Z TO 2000-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2000</a></li>
 </ul>
 <p>
-Search one decade at a time.
+Search by decade.
 <ul>
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2000-01-01T00:00:00Z%20TO%202009-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2000-2009</a></li>
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1990-01-01T00:00:00Z%20TO%201999-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1990-1999</a></li>
@@ -578,7 +565,8 @@ Search one decade at a time.
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1960-01-01T00:00:00Z%20TO%201969-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1960-1969</a></li>
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1950-01-01T00:00:00Z%20TO%201959-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1950-1959</a></li>
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1940-01-01T00:00:00Z%20TO%201949-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1940-1949</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1800-01-01T00:00:00Z%20TO%201899-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1800-1899</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1900-01-01T00:00:00Z%20TO%201939-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1900-1939</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1700-01-01T00:00:00Z%20TO%201899-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">Before 1900</a></li>
 </ul>
 
 

--- a/scripts/custom_scripts/create_pages.php
+++ b/scripts/custom_scripts/create_pages.php
@@ -548,37 +548,37 @@ Search most recent contributions.
 <p>
 Search one year at a time.
 <ul>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2018-01-01T00:00:00Z TO 2018-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2018</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2017-01-01T00:00:00Z TO 2017-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2017</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2016-01-01T00:00:00Z TO 2016-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2016</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2015-01-01T00:00:00Z TO 2015-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2015</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2014-01-01T00:00:00Z TO 2014-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2014</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2013-01-01T00:00:00Z TO 2013-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2013</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2012-01-01T00:00:00Z TO 2012-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2012</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2011-01-01T00:00:00Z TO 2011-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2011</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2010-01-01T00:00:00Z TO 2010-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2010</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2009-01-01T00:00:00Z TO 2009-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2009</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2008-01-01T00:00:00Z TO 2008-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2008</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2007-01-01T00:00:00Z TO 2007-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2007</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2006-01-01T00:00:00Z TO 2006-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2006</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2005-01-01T00:00:00Z TO 2005-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2005</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2004-01-01T00:00:00Z TO 2004-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2004</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2003-01-01T00:00:00Z TO 2003-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2003</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2002-01-01T00:00:00Z TO 2002-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2002</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2001-01-01T00:00:00Z TO 2001-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2001</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2000-01-01T00:00:00Z TO 2000-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2000</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2018-01-01T00:00:00Z TO 2018-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2018</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2017-01-01T00:00:00Z TO 2017-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2017</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2016-01-01T00:00:00Z TO 2016-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2016</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2015-01-01T00:00:00Z TO 2015-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2015</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2014-01-01T00:00:00Z TO 2014-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2014</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2013-01-01T00:00:00Z TO 2013-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2013</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2012-01-01T00:00:00Z TO 2012-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2012</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2011-01-01T00:00:00Z TO 2011-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2011</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2010-01-01T00:00:00Z TO 2010-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2010</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2009-01-01T00:00:00Z TO 2009-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2009</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2008-01-01T00:00:00Z TO 2008-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2008</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2007-01-01T00:00:00Z TO 2007-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2007</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2006-01-01T00:00:00Z TO 2006-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2006</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2005-01-01T00:00:00Z TO 2005-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2005</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2004-01-01T00:00:00Z TO 2004-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2004</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2003-01-01T00:00:00Z TO 2003-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2003</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2002-01-01T00:00:00Z TO 2002-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2002</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2001-01-01T00:00:00Z TO 2001-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2001</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2000-01-01T00:00:00Z TO 2000-12-31T23:59:59Z%5D?type=edismax&sort=timestamp+desc">2000</a></li>
 </ul>
 <p>
 Search one decade at a time.
 <ul>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2000-01-01T00:00:00Z%20TO%202009-12-31T23%3A59%3A59Z]?type=edismax&sort=timestamp+desc">2000-2009</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1990-01-01T00:00:00Z%20TO%201999-12-31T23%3A59%3A59Z]?type=edismax&sort=timestamp+desc">1990-1999</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1980-01-01T00:00:00Z%20TO%201989-12-31T23%3A59%3A59Z]?type=edismax&sort=timestamp+desc">1980-1989</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1970-01-01T00:00:00Z%20TO%201979-12-31T23%3A59%3A59Z]?type=edismax&sort=timestamp+desc">1970-1979</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1960-01-01T00:00:00Z%20TO%201969-12-31T23%3A59%3A59Z]?type=edismax&sort=timestamp+desc">1960-1969</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1950-01-01T00:00:00Z%20TO%201959-12-31T23%3A59%3A59Z]?type=edismax&sort=timestamp+desc">1950-1959</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1940-01-01T00:00:00Z%20TO%201949-12-31T23%3A59%3A59Z]?type=edismax&sort=timestamp+desc">1940-1949</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1800-01-01T00:00:00Z%20TO%201899-12-31T23%3A59%3A59Z]?type=edismax&sort=timestamp+desc">1800-1899</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2000-01-01T00:00:00Z%20TO%202009-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2000-2009</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1990-01-01T00:00:00Z%20TO%201999-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1990-1999</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1980-01-01T00:00:00Z%20TO%201989-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1980-1989</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1970-01-01T00:00:00Z%20TO%201979-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1970-1979</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1960-01-01T00:00:00Z%20TO%201969-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1960-1969</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1950-01-01T00:00:00Z%20TO%201959-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1950-1959</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1940-01-01T00:00:00Z%20TO%201949-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1940-1949</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1800-01-01T00:00:00Z%20TO%201899-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1800-1899</a></li>
 </ul>
 
 

--- a/scripts/custom_scripts/create_pages.php
+++ b/scripts/custom_scripts/create_pages.php
@@ -571,7 +571,10 @@ Search one year at a time.
 <p>
 Search one decade at a time.
 <ul>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01T00:00:00Z%20TO%202009-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc3A/201[0-9].*/?type=edismax&sort=timestamp+desc%3A/201[0-9].*/?type=edismax&sort=timestamp+desc">2000-2009a</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01T00:00:00Z%20TO%202009-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc3A/201[0-9].*/?type=edismax&sort=timestamp+desc%3A/201[0-9].*/?type=edismax&sort=timestamp+desc">2000-2009aorig</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01T00:00:00Z%20TO%202009-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">2000-2009a</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[1990-01-01T00:00:00Z%20TO%201999-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=desc">1990-1999a</a></li>
+
 
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/201[0-9].*/?type=edismax&sort=timestamp+desc">2000-2009b</a></li>
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/199[0-9].*/?type=edismax&sort=timestamp+desc">1990-1999</a></li>

--- a/scripts/custom_scripts/create_pages.php
+++ b/scripts/custom_scripts/create_pages.php
@@ -70,6 +70,9 @@ $home_body =  <<<HOME_BODY
                 <li>
                     Preserve your work long-term.
                 </li>
+                <li>
+		                <a href="http://localhost:8000/iby">Find latest publications! Search by date across all Collections.</a>
+		            </li>
             </ul>
 HOME_BODY;
 
@@ -519,6 +522,71 @@ $privacy_policy_body = <<<PRIVACY_BODY
 </div>
 
 PRIVACY_BODY;
+
+$iby_body = <<<IBY_BODY
+<h4>World readable Search-by-date page</h4>
+Developer test searches
+<ul>
+<li><a href="/islandora/search/timestamp%3A[NOW-10MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 10 minutes</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-20MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 20 minutes</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-30MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 30 minutes</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-60MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 60 minutes</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-2HOURS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 hours</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-12HOURS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 12 hours</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-1DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 1 days</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-2DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 days</a></li>
+</ul>
+
+Search most recent contributions.
+<ul>
+<li><a href="/islandora/search/timestamp%3A[NOW-14DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 weeks</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-28DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 4 weeks</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-62DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 months</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-92DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 3 months</a></li>
+<li><a href="/islandora/search/timestamp%3A[NOW-183DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 6 months</a></li>
+</ul>
+<p>
+Search one year at a time.
+<ul>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2018-01-01 TO 2018-12-31]?type=edismax&sort=timestamp+desc">2018</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2017-01-01 TO 2017-12-31]?type=edismax&sort=timestamp+desc">2017</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2016-01-01 TO 2016-12-31]?type=edismax&sort=timestamp+desc">2016</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2015-01-01 TO 2015-12-31]?type=edismax&sort=timestamp+desc">2015</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2014-01-01 TO 2014-12-31]?type=edismax&sort=timestamp+desc">2014</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2013-01-01 TO 2013-12-31]?type=edismax&sort=timestamp+desc">2013</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2012-01-01 TO 2012-12-31]?type=edismax&sort=timestamp+desc">2012</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2011-01-01 TO 2011-12-31]?type=edismax&sort=timestamp+desc">2011</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2010-01-01 TO 2010-12-31]?type=edismax&sort=timestamp+desc">2010</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2009-01-01 TO 2009-12-31]?type=edismax&sort=timestamp+desc">2009</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2008-01-01 TO 2008-12-31]?type=edismax&sort=timestamp+desc">2008</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2007-01-01 TO 2007-12-31]?type=edismax&sort=timestamp+desc">2007</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2006-01-01 TO 2006-12-31]?type=edismax&sort=timestamp+desc">2006</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2005-01-01 TO 2005-12-31]?type=edismax&sort=timestamp+desc">2005</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2004-01-01 TO 2004-12-31]?type=edismax&sort=timestamp+desc">2004</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2003-01-01 TO 2003-12-31]?type=edismax&sort=timestamp+desc">2003</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2002-01-01 TO 2002-12-31]?type=edismax&sort=timestamp+desc">2002</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2001-01-01 TO 2001-12-31]?type=edismax&sort=timestamp+desc">2001</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01 TO 2000-12-31]?type=edismax&sort=timestamp+desc">2000</a></li>
+</ul>
+<p>
+Search one decade at a time.
+<ul>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/199[0-9].*/?type=edismax&sort=timestamp+desc">1990-1999</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/198[0-9].*/?type=edismax&sort=timestamp+desc">1980-1989</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/197[0-9].*/?type=edismax&sort=timestamp+desc">1970-1979</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/196[0-9].*/?type=edismax&sort=timestamp+desc">1960-1969</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/195[0-9].*/?type=edismax&sort=timestamp+desc">1950-1959</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/194[0-9].*/?type=edismax&sort=timestamp+desc">1940-1949</a></li>
+
+</ul>
+
+
+IBY_BODY;
+
+
+$iby_nid = create_named_page("iby","Search-by-date","$iby_body");
+//add_menu_link_to_trace_navigation($iby_nid, "trace-navigation", "Search-by-date", 9);
+
 
 $home_nid = create_named_page("home", "Welcome to TRACE", $home_body);
 add_menu_link_to_trace_navigation($home_nid, "trace-navigation", "Home", 1);

--- a/scripts/custom_scripts/create_pages.php
+++ b/scripts/custom_scripts/create_pages.php
@@ -524,7 +524,7 @@ $privacy_policy_body = <<<PRIVACY_BODY
 PRIVACY_BODY;
 
 $iby_body = <<<IBY_BODY
-<h4>World readable Search-by-date page</h4>
+<h4>World readable Search-by-publication-date page</h4>
 Search most recent publications.
 <ul>
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[NOW-14DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 weeks</a></li>

--- a/scripts/custom_scripts/create_pages.php
+++ b/scripts/custom_scripts/create_pages.php
@@ -527,58 +527,58 @@ $iby_body = <<<IBY_BODY
 <h4>World readable Search-by-date page</h4>
 Developer test searches
 <ul>
-<li><a href="/islandora/search/timestamp%3A[NOW-10MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 10 minutes</a></li>
-<li><a href="/islandora/search/timestamp%3A[NOW-20MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 20 minutes</a></li>
-<li><a href="/islandora/search/timestamp%3A[NOW-30MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 30 minutes</a></li>
-<li><a href="/islandora/search/timestamp%3A[NOW-60MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 60 minutes</a></li>
-<li><a href="/islandora/search/timestamp%3A[NOW-2HOURS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 hours</a></li>
-<li><a href="/islandora/search/timestamp%3A[NOW-12HOURS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 12 hours</a></li>
-<li><a href="/islandora/search/timestamp%3A[NOW-1DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 1 days</a></li>
-<li><a href="/islandora/search/timestamp%3A[NOW-2DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 days</a></li>
+<li><a href="/islandora/search/timestamp:[NOW-10MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 10 minutes</a></li>
+<li><a href="/islandora/search/timestamp:[NOW-20MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 20 minutes</a></li>
+<li><a href="/islandora/search/timestamp:[NOW-30MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 30 minutes</a></li>
+<li><a href="/islandora/search/timestamp:[NOW-60MINUTES%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 60 minutes</a></li>
+<li><a href="/islandora/search/timestamp:[NOW-2HOURS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 hours</a></li>
+<li><a href="/islandora/search/timestamp:[NOW-12HOURS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 12 hours</a></li>
+<li><a href="/islandora/search/timestamp:[NOW-1DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 1 days</a></li>
+<li><a href="/islandora/search/timestamp:[NOW-2DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 days</a></li>
 </ul>
 
 Search most recent contributions.
 <ul>
-<li><a href="/islandora/search/timestamp%3A[NOW-14DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 weeks</a></li>
-<li><a href="/islandora/search/timestamp%3A[NOW-28DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 4 weeks</a></li>
-<li><a href="/islandora/search/timestamp%3A[NOW-62DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 months</a></li>
-<li><a href="/islandora/search/timestamp%3A[NOW-92DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 3 months</a></li>
-<li><a href="/islandora/search/timestamp%3A[NOW-183DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 6 months</a></li>
+<li><a href="/islandora/search/timestamp:[NOW-14DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 weeks</a></li>
+<li><a href="/islandora/search/timestamp:[NOW-28DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 4 weeks</a></li>
+<li><a href="/islandora/search/timestamp:[NOW-62DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 months</a></li>
+<li><a href="/islandora/search/timestamp:[NOW-92DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 3 months</a></li>
+<li><a href="/islandora/search/timestamp:[NOW-183DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 6 months</a></li>
 </ul>
 <p>
 Search one year at a time.
 <ul>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2018-01-01T00:00:00Z TO 2018-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2018</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2017-01-01T00:00:00Z TO 2017-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2017</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2016-01-01T00:00:00Z TO 2016-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2016</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2015-01-01T00:00:00Z TO 2015-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2015</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2014-01-01T00:00:00Z TO 2014-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2014</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2013-01-01T00:00:00Z TO 2013-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2013</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2012-01-01T00:00:00Z TO 2012-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2012</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2011-01-01T00:00:00Z TO 2011-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2011</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2010-01-01T00:00:00Z TO 2010-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2010</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2009-01-01T00:00:00Z TO 2009-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2009</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2008-01-01T00:00:00Z TO 2008-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2008</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2007-01-01T00:00:00Z TO 2007-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2007</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2006-01-01T00:00:00Z TO 2006-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2006</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2005-01-01T00:00:00Z TO 2005-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2005</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2004-01-01T00:00:00Z TO 2004-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2004</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2003-01-01T00:00:00Z TO 2003-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2003</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2002-01-01T00:00:00Z TO 2002-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2002</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2001-01-01T00:00:00Z TO 2001-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2001</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2000-01-01T00:00:00Z TO 2000-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2000</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2018-01-01T00:00:00Z TO 2018-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2018</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2017-01-01T00:00:00Z TO 2017-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2017</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2016-01-01T00:00:00Z TO 2016-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2016</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2015-01-01T00:00:00Z TO 2015-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2015</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2014-01-01T00:00:00Z TO 2014-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2014</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2013-01-01T00:00:00Z TO 2013-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2013</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2012-01-01T00:00:00Z TO 2012-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2012</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2011-01-01T00:00:00Z TO 2011-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2011</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2010-01-01T00:00:00Z TO 2010-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2010</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2009-01-01T00:00:00Z TO 2009-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2009</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2008-01-01T00:00:00Z TO 2008-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2008</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2007-01-01T00:00:00Z TO 2007-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2007</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2006-01-01T00:00:00Z TO 2006-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2006</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2005-01-01T00:00:00Z TO 2005-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2005</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2004-01-01T00:00:00Z TO 2004-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2004</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2003-01-01T00:00:00Z TO 2003-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2003</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2002-01-01T00:00:00Z TO 2002-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2002</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2001-01-01T00:00:00Z TO 2001-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2001</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:%5B2000-01-01T00:00:00Z TO 2000-12-31T23%3A59%3A59Z%5D?type=edismax&sort=timestamp+desc">2000</a></li>
 </ul>
 <p>
 Search one decade at a time.
 <ul>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01T00:00:00Z%20TO%202009-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">2000-2009</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[1990-01-01T00:00:00Z%20TO%201999-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">1990-1999</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[1980-01-01T00:00:00Z%20TO%201989-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">1980-1989</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[1970-01-01T00:00:00Z%20TO%201979-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">1970-1979</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[1960-01-01T00:00:00Z%20TO%201969-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">1960-1969</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[1950-01-01T00:00:00Z%20TO%201959-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">1950-1959</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[1940-01-01T00:00:00Z%20TO%201949-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">1940-1949</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[1800-01-01T00:00:00Z%20TO%201899-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">1800-1899</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2000-01-01T00:00:00Z%20TO%202009-12-31T23%3A59%3A59Z]?type=edismax&sort=timestamp+desc">2000-2009</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1990-01-01T00:00:00Z%20TO%201999-12-31T23%3A59%3A59Z]?type=edismax&sort=timestamp+desc">1990-1999</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1980-01-01T00:00:00Z%20TO%201989-12-31T23%3A59%3A59Z]?type=edismax&sort=timestamp+desc">1980-1989</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1970-01-01T00:00:00Z%20TO%201979-12-31T23%3A59%3A59Z]?type=edismax&sort=timestamp+desc">1970-1979</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1960-01-01T00:00:00Z%20TO%201969-12-31T23%3A59%3A59Z]?type=edismax&sort=timestamp+desc">1960-1969</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1950-01-01T00:00:00Z%20TO%201959-12-31T23%3A59%3A59Z]?type=edismax&sort=timestamp+desc">1950-1959</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1940-01-01T00:00:00Z%20TO%201949-12-31T23%3A59%3A59Z]?type=edismax&sort=timestamp+desc">1940-1949</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1800-01-01T00:00:00Z%20TO%201899-12-31T23%3A59%3A59Z]?type=edismax&sort=timestamp+desc">1800-1899</a></li>
 </ul>
 
 

--- a/scripts/custom_scripts/create_pages.php
+++ b/scripts/custom_scripts/create_pages.php
@@ -525,15 +525,13 @@ PRIVACY_BODY;
 
 $iby_body = <<<IBY_BODY
 <h4>World readable Search-by-date page</h4>
-Search most recent contributions.
+Search most recent publications.
 <ul>
-<li><a href="/islandora/search/timestamp:[NOW-14DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 weeks timestamp</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[NOW-14DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 weeks dateIssued</a></li>
-<li><a href="/islandora/search/timestamp:[NOW-183DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 6 months timestamp</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[NOW-183DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 6 months dateIssued</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[NOW-14DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 weeks</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[NOW-183DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 6 months</a></li>
 </ul>
 <p>
-Search one year at a time.
+Search by year of publication.
 <ul>
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2018-01-01T00:00:00Z TO 2018-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2018</a></li>
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2017-01-01T00:00:00Z TO 2017-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2017</a></li>
@@ -556,7 +554,7 @@ Search one year at a time.
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2000-01-01T00:00:00Z TO 2000-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2000</a></li>
 </ul>
 <p>
-Search by decade.
+Search by decade of publication.
 <ul>
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2000-01-01T00:00:00Z%20TO%202009-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2000-2009</a></li>
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1990-01-01T00:00:00Z%20TO%201999-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1990-1999</a></li>

--- a/scripts/custom_scripts/create_pages.php
+++ b/scripts/custom_scripts/create_pages.php
@@ -571,7 +571,9 @@ Search one year at a time.
 <p>
 Search one decade at a time.
 <ul>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/201[0-9].*/?type=edismax&sort=timestamp+desc">2000-2009</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01T00:00:00Z%20TO%202009-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc3A/201[0-9].*/?type=edismax&sort=timestamp+desc%3A/201[0-9].*/?type=edismax&sort=timestamp+desc">2000-2009a</a></li>
+
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/201[0-9].*/?type=edismax&sort=timestamp+desc">2000-2009b</a></li>
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/199[0-9].*/?type=edismax&sort=timestamp+desc">1990-1999</a></li>
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/199[0-9].*/?type=edismax&sort=timestamp+desc">1990-1999</a></li>
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/198[0-9].*/?type=edismax&sort=timestamp+desc">1980-1989</a></li>

--- a/scripts/custom_scripts/create_pages.php
+++ b/scripts/custom_scripts/create_pages.php
@@ -571,21 +571,14 @@ Search one year at a time.
 <p>
 Search one decade at a time.
 <ul>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01T00:00:00Z%20TO%202009-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc3A/201[0-9].*/?type=edismax&sort=timestamp+desc%3A/201[0-9].*/?type=edismax&sort=timestamp+desc">2000-2009aorig</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01T00:00:00Z%20TO%202009-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">2000-2009a</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[1990-01-01T00:00:00Z%20TO%201999-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=desc">1990-1999a</a></li>
-
-
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/201[0-9].*/?type=edismax&sort=timestamp+desc">2000-2009b</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/199[0-9].*/?type=edismax&sort=timestamp+desc">1990-1999</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/199[0-9].*/?type=edismax&sort=timestamp+desc">1990-1999</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/198[0-9].*/?type=edismax&sort=timestamp+desc">1980-1989</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/197[0-9].*/?type=edismax&sort=timestamp+desc">1970-1979</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/196[0-9].*/?type=edismax&sort=timestamp+desc">1960-1969</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/195[0-9].*/?type=edismax&sort=timestamp+desc">1950-1959</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/194[0-9].*/?type=edismax&sort=timestamp+desc">1940-1949</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/19[0-3].*/?type=edismax&sort=timestamp+desc">1900-1939</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/18[0-9].*/?type=edismax&sort=timestamp+desc">1800-1899</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01T00:00:00Z%20TO%202009-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">2000-2009</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[1990-01-01T00:00:00Z%20TO%201999-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">1990-1999</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[1980-01-01T00:00:00Z%20TO%201989-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">1980-1989</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[1970-01-01T00:00:00Z%20TO%201979-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">1970-1979</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[1960-01-01T00:00:00Z%20TO%201969-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">1960-1969</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[1950-01-01T00:00:00Z%20TO%201959-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">1950-1959</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[1940-01-01T00:00:00Z%20TO%201949-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">1940-1949</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[1800-01-01T00:00:00Z%20TO%201899-12-31T23%3A59%3A59Z]%3Ftype=edismax&sort=timestamp+desc">1800-1899</a></li>
 </ul>
 
 

--- a/scripts/custom_scripts/create_pages.php
+++ b/scripts/custom_scripts/create_pages.php
@@ -571,6 +571,8 @@ Search one year at a time.
 <p>
 Search one decade at a time.
 <ul>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/201[0-9].*/?type=edismax&sort=timestamp+desc">2000-2009</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/199[0-9].*/?type=edismax&sort=timestamp+desc">1990-1999</a></li>
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/199[0-9].*/?type=edismax&sort=timestamp+desc">1990-1999</a></li>
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/198[0-9].*/?type=edismax&sort=timestamp+desc">1980-1989</a></li>
 <li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/197[0-9].*/?type=edismax&sort=timestamp+desc">1970-1979</a></li>

--- a/scripts/custom_scripts/create_pages.php
+++ b/scripts/custom_scripts/create_pages.php
@@ -548,36 +548,37 @@ Search most recent contributions.
 <p>
 Search one year at a time.
 <ul>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2018-01-01 TO 2018-12-31]?type=edismax&sort=timestamp+desc">2018</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2017-01-01 TO 2017-12-31]?type=edismax&sort=timestamp+desc">2017</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2016-01-01 TO 2016-12-31]?type=edismax&sort=timestamp+desc">2016</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2015-01-01 TO 2015-12-31]?type=edismax&sort=timestamp+desc">2015</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2014-01-01 TO 2014-12-31]?type=edismax&sort=timestamp+desc">2014</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2013-01-01 TO 2013-12-31]?type=edismax&sort=timestamp+desc">2013</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2012-01-01 TO 2012-12-31]?type=edismax&sort=timestamp+desc">2012</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2011-01-01 TO 2011-12-31]?type=edismax&sort=timestamp+desc">2011</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2010-01-01 TO 2010-12-31]?type=edismax&sort=timestamp+desc">2010</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2009-01-01 TO 2009-12-31]?type=edismax&sort=timestamp+desc">2009</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2008-01-01 TO 2008-12-31]?type=edismax&sort=timestamp+desc">2008</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2007-01-01 TO 2007-12-31]?type=edismax&sort=timestamp+desc">2007</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2006-01-01 TO 2006-12-31]?type=edismax&sort=timestamp+desc">2006</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2005-01-01 TO 2005-12-31]?type=edismax&sort=timestamp+desc">2005</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2004-01-01 TO 2004-12-31]?type=edismax&sort=timestamp+desc">2004</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2003-01-01 TO 2003-12-31]?type=edismax&sort=timestamp+desc">2003</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2002-01-01 TO 2002-12-31]?type=edismax&sort=timestamp+desc">2002</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2001-01-01 TO 2001-12-31]?type=edismax&sort=timestamp+desc">2001</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A[2000-01-01 TO 2000-12-31]?type=edismax&sort=timestamp+desc">2000</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2018-01-01T00:00:00Z TO 2018-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2018</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2017-01-01T00:00:00Z TO 2017-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2017</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2016-01-01T00:00:00Z TO 2016-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2016</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2015-01-01T00:00:00Z TO 2015-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2015</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2014-01-01T00:00:00Z TO 2014-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2014</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2013-01-01T00:00:00Z TO 2013-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2013</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2012-01-01T00:00:00Z TO 2012-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2012</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2011-01-01T00:00:00Z TO 2011-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2011</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2010-01-01T00:00:00Z TO 2010-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2010</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2009-01-01T00:00:00Z TO 2009-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2009</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2008-01-01T00:00:00Z TO 2008-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2008</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2007-01-01T00:00:00Z TO 2007-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2007</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2006-01-01T00:00:00Z TO 2006-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2006</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2005-01-01T00:00:00Z TO 2005-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2005</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2004-01-01T00:00:00Z TO 2004-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2004</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2003-01-01T00:00:00Z TO 2003-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2003</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2002-01-01T00:00:00Z TO 2002-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2002</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2001-01-01T00:00:00Z TO 2001-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2001</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt%3A%5B2000-01-01T00:00:00Z TO 2000-12-31T23%3A59%3A59Z%5D%3Ftype=edismax&sort=timestamp+desc">2000</a></li>
 </ul>
 <p>
 Search one decade at a time.
 <ul>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/199[0-9].*/?type=edismax&sort=timestamp+desc">1990-1999</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/198[0-9].*/?type=edismax&sort=timestamp+desc">1980-1989</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/197[0-9].*/?type=edismax&sort=timestamp+desc">1970-1979</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/196[0-9].*/?type=edismax&sort=timestamp+desc">1960-1969</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/195[0-9].*/?type=edismax&sort=timestamp+desc">1950-1959</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt/194[0-9].*/?type=edismax&sort=timestamp+desc">1940-1949</a></li>
-
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/199[0-9].*/?type=edismax&sort=timestamp+desc">1990-1999</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/198[0-9].*/?type=edismax&sort=timestamp+desc">1980-1989</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/197[0-9].*/?type=edismax&sort=timestamp+desc">1970-1979</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/196[0-9].*/?type=edismax&sort=timestamp+desc">1960-1969</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/195[0-9].*/?type=edismax&sort=timestamp+desc">1950-1959</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/194[0-9].*/?type=edismax&sort=timestamp+desc">1940-1949</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/19[0-3].*/?type=edismax&sort=timestamp+desc">1900-1939</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_s%3A/18[0-9].*/?type=edismax&sort=timestamp+desc">1800-1899</a></li>
 </ul>
 
 

--- a/scripts/custom_scripts/create_pages.php
+++ b/scripts/custom_scripts/create_pages.php
@@ -524,54 +524,53 @@ $privacy_policy_body = <<<PRIVACY_BODY
 PRIVACY_BODY;
 
 $iby_body = <<<IBY_BODY
-<h4>World readable Search-by-publication-date page</h4>
 Search most recent publications.
 <ul>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[NOW-14DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 2 weeks</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[NOW-183DAYS%20TO%20NOW]?type=edismax&sort=timestamp+desc">Last 6 months</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[NOW-14DAYS%20TO%20NOW]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">Last 2 weeks</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[NOW-183DAYS%20TO%20NOW]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">Last 6 months</a></li>
 </ul>
 <p>
 Search by year of publication.
 <ul>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2018-01-01T00:00:00Z TO 2018-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2018</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2017-01-01T00:00:00Z TO 2017-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2017</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2016-01-01T00:00:00Z TO 2016-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2016</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2015-01-01T00:00:00Z TO 2015-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2015</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2014-01-01T00:00:00Z TO 2014-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2014</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2013-01-01T00:00:00Z TO 2013-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2013</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2012-01-01T00:00:00Z TO 2012-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2012</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2011-01-01T00:00:00Z TO 2011-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2011</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2010-01-01T00:00:00Z TO 2010-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2010</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2009-01-01T00:00:00Z TO 2009-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2009</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2008-01-01T00:00:00Z TO 2008-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2008</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2007-01-01T00:00:00Z TO 2007-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2007</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2006-01-01T00:00:00Z TO 2006-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2006</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2005-01-01T00:00:00Z TO 2005-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2005</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2004-01-01T00:00:00Z TO 2004-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2004</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2003-01-01T00:00:00Z TO 2003-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2003</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2002-01-01T00:00:00Z TO 2002-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2002</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2001-01-01T00:00:00Z TO 2001-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2001</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2000-01-01T00:00:00Z TO 2000-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2000</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2018-01-01T00:00:00Z TO 2018-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2018</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2017-01-01T00:00:00Z TO 2017-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2017</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2016-01-01T00:00:00Z TO 2016-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2016</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2015-01-01T00:00:00Z TO 2015-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2015</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2014-01-01T00:00:00Z TO 2014-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2014</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2013-01-01T00:00:00Z TO 2013-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2013</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2012-01-01T00:00:00Z TO 2012-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2012</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2011-01-01T00:00:00Z TO 2011-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2011</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2010-01-01T00:00:00Z TO 2010-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2010</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2009-01-01T00:00:00Z TO 2009-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2009</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2008-01-01T00:00:00Z TO 2008-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2008</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2007-01-01T00:00:00Z TO 2007-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2007</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2006-01-01T00:00:00Z TO 2006-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2006</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2005-01-01T00:00:00Z TO 2005-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2005</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2004-01-01T00:00:00Z TO 2004-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2004</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2003-01-01T00:00:00Z TO 2003-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2003</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2002-01-01T00:00:00Z TO 2002-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2002</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2001-01-01T00:00:00Z TO 2001-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2001</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2000-01-01T00:00:00Z TO 2000-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2000</a></li>
 </ul>
 <p>
 Search by decade of publication.
 <ul>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2000-01-01T00:00:00Z%20TO%202009-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">2000-2009</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1990-01-01T00:00:00Z%20TO%201999-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1990-1999</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1980-01-01T00:00:00Z%20TO%201989-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1980-1989</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1970-01-01T00:00:00Z%20TO%201979-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1970-1979</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1960-01-01T00:00:00Z%20TO%201969-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1960-1969</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1950-01-01T00:00:00Z%20TO%201959-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1950-1959</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1940-01-01T00:00:00Z%20TO%201949-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1940-1949</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1900-01-01T00:00:00Z%20TO%201939-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">1900-1939</a></li>
-<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1700-01-01T00:00:00Z%20TO%201899-12-31T23:59:59Z]?type=edismax&sort=timestamp+desc">Before 1900</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[2000-01-01T00:00:00Z%20TO%202009-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">2000-2009</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1990-01-01T00:00:00Z%20TO%201999-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">1990-1999</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1980-01-01T00:00:00Z%20TO%201989-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">1980-1989</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1970-01-01T00:00:00Z%20TO%201979-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">1970-1979</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1960-01-01T00:00:00Z%20TO%201969-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">1960-1969</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1950-01-01T00:00:00Z%20TO%201959-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">1950-1959</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1940-01-01T00:00:00Z%20TO%201949-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">1940-1949</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1900-01-01T00:00:00Z%20TO%201939-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">1900-1939</a></li>
+<li><a href="/islandora/search/mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt:[1000-01-01T00:00:00Z%20TO%201899-12-31T23:59:59Z]?type=edismax&sort=mods_originInfo_encoding_etdf_keyDate_yes_dateIssued_dt%20desc">Before 1900</a></li>
 </ul>
 
 
 IBY_BODY;
 
 
-$iby_nid = create_named_page("iby","Search-by-date","$iby_body");
+$iby_nid = create_named_page("iby","Search by publication date","$iby_body");
 //add_menu_link_to_trace_navigation($iby_nid, "trace-navigation", "Search-by-date", 9);
 
 


### PR DESCRIPTION
** JIRA Ticket**: (link)
https://jira.lib.utk.edu/browse/TRAC-1029 [Create the Year-Index.htm page for trace.utk.edu]Other 

*Relevant Link
    https://scholar.google.com/intl/en/scholar/inclusion.html

#What does this pull request do?
Address TRAC-1029 by creating a world readable Search by year page for Google Scholar Inclusion.

The file to be revised is:  Trace/scripts/custom_scripts/create_pages.php.
a. add IBY_BODY code to build the HTML file presented for Google Scholar Inclusion
b. revise HOME_BODY code to create the link (http://localhost:8000/iby) to give access to the IBY_BODY page.

All of the searches described here search the field: mods_originInfo_encoding_edtf_keyDate_yes_dateIssued_dt
This field is for Publication Date.

Searches required by Google Scholar are Last-2-weeks, Search-by-year (going back at least 5 years).  

Other searches are included for use by our public audience.

*How should this be tested:

The only Collection that works for submission on vagrant is Graduate Theses and Dissertations.

    Checkout Trace(TRAC-1029e), do vagrant up.

    On the home page, click on the link: "Find latest publications! Search by date across all collections."
    -- This should take you to: http://localhost:8000/iby
    -- If not, contact me immediately. We have to deliver this for Google Scholar Inclusion.

    Add an etd by userA
    Make sure the Date of Award is in the ***PAST*** (my suggestion: date-of_award December 2016) or else the etd will not be seen in the collection until after the ***FUTURE*** date of award.
    SUBMIT. LOGOUT.

    LOGIN as thesis_manager, accept, publish.

    LOG OUT and become a non-authenticated user because these searches are supposed to be World-Readable.

    Click on the link for "Find latest..." ( localhost:8000/iby )
    Search on "Last 2 weeks".
    Even though dateModified for userA etd is very recent, this search should return nothing
    because date-of-award for userA etd is December-2016.
    If not, fail this test and fail the request.

    Go back to localhost:8000/iby
    Default test collections include date of publication 2016.
    Click on Search- by year: 2016
    This should return results, including the userA etd submission.
    If not, fail this test and fail the request.

    Go back to localhost:8000/iby
    Default test collections include date of publication 2008.
    Click on Search- by decade:  2000-2009
    This should return results.
    It should not return userA etd with date-of-award 2016.
    If not, fail this test and fail the request.

    If none of the three tests fail, pass the pull request.

Interested parties

@DonRichards
@CanOfBees

