### PR TITLE
Remove http://localhost:8000 from link address to make code portable.

### DIFF
--- a/scripts/custom_scripts/create_pages.php
+++ b/scripts/custom_scripts/create_pages.php
@@ -71,7 +71,7 @@ $home_body =  <<<HOME_BODY
                     Preserve your work long-term.
                 </li>
                 <li>
-		                <a href="http://localhost:8000/iby">Find latest publications! Search by date across all Collections.</a>
+		                <a href="/iby">Find latest publications! Search by date across all Collections.</a>
 		            </li>
             </ul>
 HOME_BODY;


### PR DESCRIPTION
** JIRA Ticket**: 
TRAC-1167 Revise create_pages.php. Remove links that use localhost:8000 as http prefix
https://jira.lib.utk.edu/browse/TRAC-1167

# What does this Pull Request do?

The link for search-by-date on the TRACE Home Page contains the prefix 
<pre>http://localhost:8000</pre>

This makes the code work in vagrant and not on other servers.

# What's new?

The vagrant specific prefix has been removed.


# How should this be tested?

In your local github repo, go to TRACE

checkout TRAC-1167-trace-chd

Do vagrant up.

When vagrant up is finished, go to TRACE Home page.  http://localhost:8000/

Do view source.

Search for the string "Find latest"

You should see the following in view-source:

<pre>&lt;a href="/iby" >Find latest publications.  Search by date.&lt;/a></pre>

This is the portable link.

Return to the TRACE Home page, click on this "Find latest" link and make sure you are getting to the search-by-date (iby) page.

This changes the behavior by making the page work correctly on all servers.

No changes in documentation, dependencies, or the repository are caused by this change.



# Interested parties
@CanOfBees @DonRichards @robert-patrick-waltz 
Tag (@ mention) interested parties or, if unsure, @utkdigitalinitiatives/digital-initiatives-developers
