### PR TITLE
address TRAC-1191: add a shell script to Trace to pull in changes/mod…

### DIFF
--- a/scripts/custom_scripts/869_update_mods_to_dc.sh
+++ b/scripts/custom_scripts/869_update_mods_to_dc.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+## this shell script clones a repository and updates the mods_to_dc stylesheets that are scattered around our $DRUPAL_HOME
+
+echo "Checking for the utk-mods-to-dc repository"
+
+cd "$HOME_DIR" || exit
+if [ ! -d "$HOME_DIR"/utk-mods-to-dc ]; then
+	echo "Cloning utk-mods-to-dc"
+	git clone https://github.com/utkdigitalinitiatives/utk-mods-to-dc
+	chown -hR vagrant:vagrant utk-mods-to-dc
+else
+	cd utk-mods-to-dc || exit
+	echo "Updating the utk-mods-to-dc repository"
+	git pull
+fi
+
+# update the modules
+echo "Replacing the old mods_to_dc stylesheets"
+sudo cp "$HOME_DIR"/utk-mods-to-dc/institutional-repository/mods_to_dc.xsl /var/www/drupal/sites/all/modules/islandora_xml_forms/builder/transforms/mods_to_dc.xsl
+sudo chown -hR vagrant:vagrant /var/www/drupal/sites/all/modules/islandora_xml_forms
+
+sudo cp "$HOME_DIR"/utk-mods-to-dc/institutional-repository/mods_to_dc.xsl /var/www/drupal/sites/all/modules/islandora_batch/transforms/mods_to_dc.xsl
+sudo chown -hR vagrant:vagrant /var/www/drupal/sites/all/modules/islandora_batch
+
+sudo cp "$HOME_DIR"/utk-mods-to-dc/institutional-repository/mods_to_dc.xsl /var/www/drupal/sites/all/modules/islandora_importer/xsl/mods_to_dc.xsl
+sudo chown -hR vagrant:vagrant /var/www/drupal/sites/all/modules/islandora_importer


### PR DESCRIPTION
…ifications from the utk-mods-to-dc repository.

** JIRA Ticket**: [TRAC-1191](https://jira.lib.utk.edu/browse/TRAC-1191)

# What does this Pull Request do?
This PR adds a shellscript that pulls in the new mods_to_dc.xsl and updates the current versions.

# What's new?
A shellscript that clones a repository, then copies a file to various places in `$DRUPAL_HOME/sites/all/modules/`, specifically

```shell
islandora_batch/transforms/
islandora_importer/xsl/
islandora_xml_forms/builder/transforms/
```
# How should this be tested?
1. `vagrant destroy -f`
2. acquire this feature branch
3. `vagrant up`
4. after vagrant has finished building the VM, visit `http://localhost:8000/islandora/object/utk.ir%3Atd` and look for the following two things:
  a. Dates = YYYY-MM (instead of YYYY-MM-ddThh:mm:ss-T)
  b. Description = only the value of mods:abstract. _Caveat_: it looks like there's a truncation happening with description/abstract in 'Browse'. You can verify this by e.g. visiting a PID/datastream/MODS and PID/datastream/DC and comparing the values of `mods:abstract` and `dc:description`.

# Interested parties
@markpbaggett @DonRichards 
Edit: adding some other peoples 
@robert-patrick-waltz @cdeaneGit @pc37utn 