### PR TITLE
moved pointers to public references.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.hostname = $hostname
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "utkdigitalinitiatives/TRACE"
-  config.vm.box = "TRACE"
+  #config.vm.box = "TRACE"
   #config.vm.box = "c7vbb"
 
   # config.vm.box_url = "http://dlwork.lib.utk.edu/vboxes/u14plus.json"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,11 +21,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.hostname = $hostname
   # Every Vagrant virtual environment requires a box to build off of.
-  # config.vm.box = "islandora/islandora-base"
+  config.vm.box = "utkdigitalinitiatives/TRACE"
   config.vm.box = "TRACE"
   #config.vm.box = "c7vbb"
 
-  config.vm.box_url = "http://dlwork.lib.utk.edu/vboxes/u14plus.json"
+  # config.vm.box_url = "http://dlwork.lib.utk.edu/vboxes/u14plus.json"
   #config.vm.box_url = "http://dlwork.lib.utk.edu/vboxes/c7vbb.json"
   # config.vm.box_version = "0.1.4"
   shared_dir = "/vagrant"

--- a/scripts/custom_scripts/870_ingest_sample_theses.sh
+++ b/scripts/custom_scripts/870_ingest_sample_theses.sh
@@ -7,13 +7,13 @@ if [ ! -d "$HOME_DIR"/sample_data ]; then
   mkdir sample_data || exit
   chown -hR vagrant:vagrant sample_data
   cd sample_data || exit
-  curl -s -O http://dlwork.lib.utk.edu/trace_sample_data/trace_sample_data.tar.gz
+  curl -s -O http://dlwork.lib.utk.edu/vboxes/trace_sample_data.tar.gz
   tar -xvzf trace_sample_data.tar.gz
 else
   cd sample_data || exit
   echo "Updating Example Thesis Records"
   chown -hR vagrant:vagrant sample_data
-  curl -s -O http://dlwork.lib.utk.edu/trace_sample_data/trace_sample_data.tar.gz
+  curl -s -O http://dlwork.lib.utk.edu/vboxes/trace_sample_data.tar.gz
   tar -xvzf trace_sample_data.tar.gz
 fi
 


### PR DESCRIPTION
** JIRA Ticket**: https://jira.lib.utk.edu/browse/TRAC-1199

# What does this Pull Request do?

1) Moves virtualbox pointer to vagrantup.com
2) Points to a new set of test files that don't include student submissions. 

# What's new?
* New vagrantup.com repo
* http://dlwork.lib.utk.edu/vboxes/u14plus.json

# How should this be tested?
Stop all instances of TRACE/vagrant and remove all of the cached boxes. If this step is skipped and the new one issn't found vagrant will back on the old one and will not notify you of the issue.
```bash
$ vagrant box prune
$ vagrant box list
TRACE (virtualbox, 0.1.7.1)

# Delete it by running vagrant box remove NAME
$ vagrant box remove TRACE
```
Next, switch to this PR and run vagrant up.

This should take some time because it's downloading the vagrant box all over again.

Verify the test data has imported corrected. All of the PDFs it imports are exactly the same and the title and body of the submissions will include multiple other languages that are unicode compliant (like Armenian, Greek, Russian, etc).

To check that it pulled the correct vagrant box after running vagrant up, run the following command
```bash
$ vagrant box list
utkdigitalinitiatives/TRACE (virtualbox, 0.1.8)

```

# Additional Notes:
N/A

# Interested parties
@utkdigitalinitiatives/digital-initiatives-developers